### PR TITLE
prevent repeated var names in cross-val tutorial

### DIFF
--- a/docs/ci-tutorials/crossvalidation.md
+++ b/docs/ci-tutorials/crossvalidation.md
@@ -185,11 +185,11 @@ The following plots visualize how we've split up the data. For each $K$-fold, we
 ```{code-cell}
 fig, ax = plt.subplots(nrows=k, ncols=3, figsize=(6, 10))
 
-for i, (train, test) in enumerate(k_fold_datasets):
+for i, (train_subset, test_subset) in enumerate(k_fold_datasets):
 
-    rtrain = connectors.GriddedResidualConnector(flayer, train)
+    rtrain = connectors.GriddedResidualConnector(flayer, train_subset)
     rtrain.forward()
-    rtest = connectors.GriddedResidualConnector(flayer, test)
+    rtest = connectors.GriddedResidualConnector(flayer, test_subset)
     rtest.forward()
 
     vis_ext = rtrain.coords.vis_ext


### PR DESCRIPTION
closes #95 

Just changing variable names in the cross-val tutorial (names `train` and `test` are used twice) to prevent redundant names and possible confusion for those taking code from the tutorial. 