### PR TITLE
enforce KFoldCrossValidatorGridded to cpu

### DIFF
--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -361,6 +361,7 @@ class KFoldCrossValidatorGridded:
         q_edges (1D numpy array): an array of radial bin edges to set the dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults to 12 log-linearly radial bins stretching from 0 to the :math:`q_\mathrm{max}` represented by ``coords``.
         phi_edges (1D numpy array): an array of azimuthal bin edges to set the dartboard cells in [radians]. If ``None``, defaults to 8 equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
         npseed (int): (optional) numpy random seed to use for the permutation, for reproducibility
+        verbose (int), default=0: level of verbosity of log messages
 
     Once initialized, iterate through the datasets like
 
@@ -380,7 +381,14 @@ class KFoldCrossValidatorGridded:
         q_edges=None,
         phi_edges=None,
         npseed=None,
+        verbose=0
     ):
+
+        # for ease of interface with numpy, enforce that griddedDataset tensors be on the CPU  
+        if griddedDataset.vis_gridded.is_cuda:
+            griddedDataset = griddedDataset.to('cpu')
+            if verbose > 0:
+                print('KFoldCrossValidatorGridded: moving griddedDataset to CPU')
 
         self.griddedDataset = griddedDataset
 


### PR DESCRIPTION
Moves all objects/operations in `datasets.KFoldCrossValidatorGridded` to the CPU, for ease of numpy usage. 