### PR TITLE
get_optimal_image_properties utility

### DIFF
--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -281,7 +281,7 @@ def get_optimal_image_properties(image_width, q, percentile=None,
         q_optimal = np.percentile(q, percentile)
     else:
         q_optimal = target_baseline
-        
+
     cell_size = get_maximum_cell_size(q_optimal)
 
     # round the desired number of pixels up to the nearest integer
@@ -291,37 +291,6 @@ def get_optimal_image_properties(image_width, q, percentile=None,
         npix += 1
 
     return cell_size, npix
-
-
-def get_optimal_npixel(q, npixels, percentile=100):
-    r"""
-    For a desired image, determine the maximum pixel size that ensures Nyquist 
-    sampling of the provided baseline distribution out to its chosen 
-    percentile.
-
-    N.B.: No assumption or correction is made concerning whether the baseline 
-    distribution is projected or deprojected.
-
-    Parameters
-    ----------
-    q : array, unit = :math:`k\lambda`
-        Baseline distribution (all values must be non-negative).
-    percentile : int, default = 100
-        Percentile of the baseline distribution out to which the desired image 
-        will Nyquist sample. 
-
-    Returns
-    -------
-    cell_size : float, unit = arcsec
-        Image pixel size required to Nyquist sample.
-    """
-
-    assert np.all(q >= 0), "All baselines should be >=0." 
-        
-    q_optimal = np.percentile(q, percentile)
-    cell_size = get_maximum_cell_size(q_optimal)
-
-    return cell_size
 
 
 def sky_gaussian_radians(l, m, a, delta_l, delta_m, sigma_l, sigma_m, Omega):

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -273,7 +273,7 @@ def get_optimal_image_properties(image_width, q, percentile=None,
     """
 
     assert np.all(q >= 0), "All baselines should be >=0." 
-    if percentile is not None and target_baseline is not None:
+    if percentile and target_baseline:
         raise ValueError("One of 'percentile' and 'target_baseline' must be " 
                         "None.")
 

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -237,31 +237,27 @@ def get_maximum_cell_size(uu_vv_point):
     return 1 / ((2 - 1) * uu_vv_point * 1e3) / arcsec
 
 
-def get_optimal_image_properties(image_width, q, percentile=None, 
-                                target_baseline=None):
+def get_optimal_image_properties(image_width, q, percentile=100):
     r"""
     For an image of desired width, determine the maximum pixel size that 
-    ensures Nyquist sampling of the provided baseline distribution out to a 
-    chosen percentile (or specific baseline), and the number of pixels 
+    ensures Nyquist sampling of the provided baseline (or baseline 
+    distribution) out to a chosen percentile, and the number of pixels 
     (given this pixel size) to obtain the desired image width.
 
     N.B.: No assumption or correction is made concerning whether the baseline 
-    distribution is projected or deprojected.
+    (distribution) is projected or deprojected.
 
     Parameters
     ----------
     image_width : float, unit = arcsec
         Desired width of the image (i.e., image will be a 
         image_width :math:`\times` image_width square).
-    q : array, unit = :math:`k\lambda`
-        Baseline distribution (all values must be non-negative).
-    percentile : int, default = None
+    q : float or array, unit = :math:`k\lambda`
+        Baseline distribution (all values must be non-negative). If a single 
+        value, 'percentile' has no effect.
+    percentile : int, default = 100
         Percentile of the baseline distribution (between 0 - 100) out to which 
         the desired image will Nyquist sample. 
-    target_baseline : float, optional, default = None, unit = :math:`k\lambda`
-        Specific baseline out to which the desired image will Nyquist sample 
-        (as an alternative to 'percentile'). One of 'percentile' and 
-        'target_baseline' must be None. 
 
     Returns
     -------
@@ -273,15 +269,8 @@ def get_optimal_image_properties(image_width, q, percentile=None,
     """
 
     assert np.all(q >= 0), "All baselines should be >=0." 
-    if percentile and target_baseline:
-        raise ValueError("One of 'percentile' and 'target_baseline' must be " 
-                        "None.")
 
-    if percentile:
-        q_optimal = np.percentile(q, percentile)
-    else:
-        q_optimal = target_baseline
-
+    q_optimal = np.percentile(q, percentile)
     cell_size = get_maximum_cell_size(q_optimal)
 
     # round the desired number of pixels up to the nearest integer

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -241,11 +241,8 @@ def get_optimal_image_properties(image_width, q, percentile=100):
     r"""
     For an image of desired width, determine the maximum pixel size that 
     ensures Nyquist sampling of the provided baseline (or baseline 
-    distribution) out to a chosen percentile, and the number of pixels 
+    distribution, out to a chosen percentile), and the number of pixels 
     (given this pixel size) to obtain the desired image width.
-
-    N.B.: No assumption or correction is made concerning whether the baseline 
-    (distribution) is projected or deprojected.
 
     Parameters
     ----------
@@ -266,6 +263,14 @@ def get_optimal_image_properties(image_width, q, percentile=100):
     npix : int
         Number of pixels of cell_size to equal (or slightly exceed) the image 
         width (npix will be rounded up and enforced as even).
+
+    Notes
+    -----
+    To obtain the image properties for a single baseline distance, pass 'q' as 
+    a float. In this case, 'percentile' has no effect.
+
+    No assumption or correction is made concerning whether the baseline 
+    (distribution) is projected or deprojected.
     """
 
     assert np.all(q >= 0), "All baselines should be >=0." 

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -237,12 +237,13 @@ def get_maximum_cell_size(uu_vv_point):
     return 1 / ((2 - 1) * uu_vv_point * 1e3) / arcsec
 
 
-def get_optimal_image_properties(image_width, q, percentile=100):
+def get_optimal_image_properties(image_width, q, percentile=None, 
+                                target_baseline=None):
     r"""
     For an image of desired width, determine the maximum pixel size that 
     ensures Nyquist sampling of the provided baseline distribution out to a 
-    chosen percentile, and the number of pixels (given this pixel size) to 
-    obtain the desired image width.
+    chosen percentile (or specific baseline), and the number of pixels 
+    (given this pixel size) to obtain the desired image width.
 
     N.B.: No assumption or correction is made concerning whether the baseline 
     distribution is projected or deprojected.
@@ -254,9 +255,13 @@ def get_optimal_image_properties(image_width, q, percentile=100):
         image_width :math:`\times` image_width square).
     q : array, unit = :math:`k\lambda`
         Baseline distribution (all values must be non-negative).
-    percentile : int, default = 100
-        Percentile of the baseline distribution out to which the desired image 
-        will Nyquist sample. 
+    percentile : int, default = None
+        Percentile of the baseline distribution (between 0 - 100) out to which 
+        the desired image will Nyquist sample. 
+    target_baseline : float, optional, default = None, unit = :math:`k\lambda`
+        Specific baseline out to which the desired image will Nyquist sample 
+        (as an alternative to 'percentile'). One of 'percentile' and 
+        'target_baseline' must be None. 
 
     Returns
     -------
@@ -268,8 +273,15 @@ def get_optimal_image_properties(image_width, q, percentile=100):
     """
 
     assert np.all(q >= 0), "All baselines should be >=0." 
-    
-    q_optimal = np.percentile(q, percentile)
+    if percentile is not None and target_baseline is not None:
+        raise ValueError("One of 'percentile' and 'target_baseline' must be " 
+                        "None.")
+
+    if percentile:
+        q_optimal = np.percentile(q, percentile)
+    else:
+        q_optimal = target_baseline
+        
     cell_size = get_maximum_cell_size(q_optimal)
 
     # round the desired number of pixels up to the nearest integer


### PR DESCRIPTION
Adds a utility function that just calculates an optimal (i.e. Nyquist) image pixel size and number of pixels given a desired total image width and a baseline (or a baseline distribution, in which case user can specify a percentile of the distribution out to which the pixel size will Nyquist sample).

'Baseline' here is technically u, v or q, as the routine makes no assumption about projection/deprojection, as noted in the docstring.