### PR TITLE
tests.yml: move linter after mpol install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Install pip
         run: |
           pip install --upgrade pip
+      - name: Install vanilla package
+        run: |
+          pip install .
+      - name: Install test dependencies
+        run: |
+          pip install .[test]
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -59,12 +65,6 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Install vanilla package
-        run: |
-          pip install .
-      - name: Install test dependencies
-        run: |
-          pip install .[test]
       - name: Cache/Restore the .mpol folder cache
         uses: actions/cache@v3
         env:


### PR DESCRIPTION
bugfix: changes order of `tests.yml` to install mpol (and test dependencies) before running linter