### PR TITLE
_setup_coord method replaced with classmethods

### DIFF
--- a/examples/HD143006/common_data.py
+++ b/examples/HD143006/common_data.py
@@ -1,18 +1,19 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from mpol import (
-    losses,
-    coordinates,
-    images,
-    precomposed,
-    gridding,
-    datasets,
-    connectors,
-    utils,
-)
 from astropy.utils.data import download_file
 from ray import tune
-import matplotlib.pyplot as plt
+
+from mpol import (
+    connectors,
+    coordinates,
+    datasets,
+    gridding,
+    images,
+    losses,
+    precomposed,
+    utils,
+)
 
 # load the data
 fname = "HD143006_continuum.npz"
@@ -29,8 +30,6 @@ coords = coordinates.GridCoords(cell_size=0.01, npix=512)
 
 gridder = gridding.Gridder(
     coords=coords,
-    uu=uu,
-    vv=vv,
     weight=weight,
     data_re=data_re,
     data_im=data_im,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ EXTRA_REQUIRES = {
 }
 
 EXTRA_REQUIRES["dev"] = (
-    EXTRA_REQUIRES["test"] + EXTRA_REQUIRES["docs"] + ["pylint", "black", "pre-commit"]
+    EXTRA_REQUIRES["test"] + EXTRA_REQUIRES["docs"] + ["pylint", "black", "pre-commit", "mypy"]
 )
 
 
@@ -80,9 +80,11 @@ setuptools.setup(
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )

--- a/src/mpol/constants.py
+++ b/src/mpol/constants.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import Final
+
+import astropy.constants as apy_const
 import numpy as np
-from astropy.constants import c, k_B
 
 # convert from arcseconds to radians
-arcsec = np.pi / (180.0 * 3600)  # [radians]  = 1/206265 radian/arcsec
+arcsec: Final[float] = np.pi / (180.0 * 3600)  # [radians]  = 1/206265 radian/arcsec
 
-deg = np.pi / 180  # [radians]
+deg: Final[float] = np.pi / 180  # [radians]
 
-kB = k_B.cgs.value  # [erg K^-1] Boltzmann constant
-cc = c.cgs.value # [cm s^-1]
-c_ms = c.value # [m s^-1]
+# Boltzmann constant
+kB: Final[float] = getattr(apy_const, "k_B").cgs.value  # [erg K^-1]
+
+# Light speed
+cc: Final[float] = getattr(apy_const, "c").cgs.value  # [cm s^-1]
+c_ms: Final[float] = getattr(apy_const, "c").value  # [m s^-1]

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -183,35 +183,3 @@ class GridCoords:
         # GridCoords objects are considered equal if they have the same cell_size and npix, since
         # all other attributes are derived from these two core properties.
         return self.cell_size == other.cell_size and self.npix == other.npix
-
-
-def _setup_coords(self, cell_size=None, npix=None, coords=None, nchan=None):
-    r"""
-    Convenience helper to setup coordinate objects inside BaseCube and ImageCube classes. This is meant to be called inside ``__init__``, and will create the instance attributes on ``self``.
-
-    Args:
-        self: reference to instance object of class.
-        cell_size (float): the width of a pixel [arcseconds]
-        npix (int): the number of pixels per image side
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        nchan (int): the number of channels in the image
-
-    Returns: None.
-    """
-    if coords:
-        assert (
-            npix is None and cell_size is None
-        ), "npix and cell_size must be empty if precomputed GridCoords are supplied."
-        self.coords = coords
-
-    elif npix or cell_size:
-        assert (
-            coords is None
-        ), "GridCoords must be empty if npix and cell_size are supplied."
-
-        self.coords = GridCoords(cell_size=cell_size, npix=npix)
-
-    if nchan is not None:
-        self.nchan = nchan
-    else:
-        self.nchan = 1

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -49,7 +49,7 @@ class GridCoords:
             raise ValueError("Image must have an even number of pixels.")
 
         if cell_size <= 0:
-            raise ValueError("cell_size must be a positive real.")
+            raise ValueError("cell_size must be a positive real number.")
 
         self.cell_size = cell_size  # arcsec
         self.npix = npix

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import copy
 
 import numpy as np
 import torch
 from torch.utils.data import Dataset
 
+from mpol.coordinates import GridCoords
+
 from . import spheroidal_gridding, utils
 from .constants import *
-from .coordinates import _setup_coords
 from .utils import loglinspace
 
 
@@ -33,17 +36,15 @@ class GriddedDataset:
 
     def __init__(
         self,
-        cell_size=None,
-        npix=None,
         coords=None,
-        nchan=None,
+        nchan=1,
         vis_gridded=None,
         weight_gridded=None,
         mask=None,
         device=None,
     ):
-
-        _setup_coords(self, cell_size, npix, coords, nchan)
+        self.coords = coords
+        self.nchan = nchan
 
         self.vis_gridded = torch.tensor(vis_gridded, device=device)
         self.weight_gridded = torch.tensor(weight_gridded, device=device)
@@ -54,6 +55,13 @@ class GriddedDataset:
         # 1D array
         self.vis_indexed = self.vis_gridded[self.mask]
         self.weight_indexed = self.weight_gridded[self.mask]
+
+    @classmethod
+    def from_image_properties(
+        cls, cell_size, npix, nchan, vis_gridded, weight_gridded, mask, device
+    ):
+        coords = GridCoords(cell_size, npix)
+        return cls(coords, nchan, vis_gridded, weight_gridded, mask, device)
 
     def add_mask(self, mask, device=None):
         r"""
@@ -147,9 +155,8 @@ class UVDataset(Dataset):
         cell_size=None,
         npix=None,
         device=None,
-        **kwargs
+        **kwargs,
     ):
-
         # assert that all vectors are the same shape
         shape = uu.shape
         for a in [vv, weights, data_re, data_im]:
@@ -236,11 +243,9 @@ class Dartboard:
 
     """
 
-    def __init__(
-        self, cell_size=None, npix=None, coords=None, q_edges=None, phi_edges=None
-    ):
-
-        _setup_coords(self, cell_size, npix, coords)
+    def __init__(self, coords=None, q_edges=None, phi_edges=None):
+        self.coords = coords
+        self.nchan = 1
 
         # copy over relevant quantities from coords
         # these are in packed format
@@ -270,6 +275,11 @@ class Dartboard:
         else:
             # set phi edges
             self.phi_edges = np.linspace(0, np.pi, num=8 + 1)  # [radians]
+
+    @classmethod
+    def from_image_properties(cls, cell_size, npix, q_edges, phi_edges) -> Dartboard:
+        coords = GridCoords(cell_size, npix)
+        return cls(coords, q_edges, phi_edges)
 
     def get_polar_histogram(self, qs, phis):
         r"""
@@ -327,7 +337,6 @@ class Dartboard:
 
         # uses about a Gb..., and this only 256x256
         for cell_index in cell_index_list:
-
             qi, pi = cell_index
             q_min, q_max = self.q_edges[qi : qi + 2]
             p0_min, p0_max = self.phi_edges[pi : pi + 2]
@@ -381,7 +390,6 @@ class KFoldCrossValidatorGridded:
         phi_edges=None,
         npseed=None,
     ):
-
         self.griddedDataset = griddedDataset
 
         assert k > 0, "k must be a positive integer"

--- a/src/mpol/exceptions.py
+++ b/src/mpol/exceptions.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class CellSizeError(Exception):
+    ...

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -69,7 +69,7 @@ class BaseCube(nn.Module):
 
     @classmethod
     def from_image_properties(
-        cls, cell_size, npix, nchan, pixel_mapping, base_cube
+        cls, cell_size, npix, nchan=1, pixel_mapping=None, base_cube=None
     ) -> BaseCube:
         coords = GridCoords(cell_size, npix)
         return cls(coords, nchan, pixel_mapping, base_cube)

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -1,5 +1,7 @@
 r"""The ``images`` module provides the core functionality of MPoL via :class:`mpol.images.ImageCube`."""
 
+from __future__ import annotations
+
 import numpy as np
 import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
@@ -7,7 +9,6 @@ from torch import nn
 
 from . import utils
 from .coordinates import GridCoords
-from .gridding import _setup_coords
 
 
 class BaseCube(nn.Module):
@@ -31,16 +32,15 @@ class BaseCube(nn.Module):
 
     def __init__(
         self,
-        cell_size=None,
-        npix=None,
         coords=None,
-        nchan=None,
+        nchan=1,
         pixel_mapping=None,
         base_cube=None,
     ):
-
         super().__init__()
-        _setup_coords(self, cell_size, npix, coords, nchan)
+
+        self.coords = coords
+        self.nchan = nchan
 
         # The ``base_cube`` is already packed to make the Fourier transformation easier
         if base_cube is None:
@@ -66,6 +66,13 @@ class BaseCube(nn.Module):
         else:
             # TODO assert that this is a PyTorch function
             self.pixel_mapping = pixel_mapping
+
+    @classmethod
+    def from_image_properties(
+        cls, cell_size, npix, nchan, pixel_mapping, base_cube
+    ) -> BaseCube:
+        coords = GridCoords(cell_size, npix)
+        return cls(coords, nchan, pixel_mapping, base_cube)
 
     def forward(self):
         r"""
@@ -103,7 +110,6 @@ class HannConvCube(nn.Module):
     """
 
     def __init__(self, nchan, requires_grad=False):
-
         super().__init__()
         # simple convolutional filter operates on per-channel basis
         # 3x3 Hann filter
@@ -178,15 +184,15 @@ class ImageCube(nn.Module):
 
     def __init__(
         self,
-        cell_size=None,
-        npix=None,
         coords=None,
-        nchan=None,
+        nchan=1,
         passthrough=False,
         cube=None,
     ):
         super().__init__()
-        _setup_coords(self, cell_size, npix, coords, nchan)
+
+        self.coords = coords
+        self.nchan = nchan
 
         self.passthrough = passthrough
 
@@ -213,6 +219,13 @@ class ImageCube(nn.Module):
             # only be provided as an arg to the forward method, not as
             # an initialization argument
             self.cube = None
+
+    @classmethod
+    def from_image_properteis(
+        cls, cell_size, npix, nchan=1, passthrough=False, cube=None
+    ) -> ImageCube:
+        coords = GridCoords(cell_size, npix)
+        return cls(coords, nchan, passthrough, cube)
 
     def forward(self, cube=None):
         r"""

--- a/src/mpol/precomposed.py
+++ b/src/mpol/precomposed.py
@@ -1,7 +1,8 @@
 import torch
 
+from mpol.coordinates import GridCoords
+
 from . import fourier, images
-from .coordinates import _setup_coords
 
 
 class SimpleNet(torch.nn.Module):
@@ -31,15 +32,14 @@ class SimpleNet(torch.nn.Module):
 
     def __init__(
         self,
-        cell_size=None,
-        npix=None,
         coords=None,
-        nchan=None,
+        nchan=1,
         base_cube=None,
     ):
         super().__init__()
 
-        _setup_coords(self, cell_size, npix, coords, nchan)
+        self.coords = coords
+        self.nchan = nchan
 
         self.bcube = images.BaseCube(
             coords=self.coords, nchan=self.nchan, base_cube=base_cube
@@ -51,6 +51,11 @@ class SimpleNet(torch.nn.Module):
             coords=self.coords, nchan=self.nchan, passthrough=True
         )
         self.fcube = fourier.FourierCube(coords=self.coords)
+
+    @classmethod
+    def from_image_properties(cls, cell_size, npix, nchan, base_cube):
+        coords = GridCoords(cell_size, npix)
+        return cls(coords, nchan, base_cube)
 
     def forward(self):
         r"""

--- a/test/coordinates_test.py
+++ b/test/coordinates_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from mpol import coordinates
 from mpol.constants import *
+from mpol.exceptions import CellSizeError
 
 
 def test_grid_coords_instantiate():
@@ -74,12 +75,12 @@ def test_grid_coords_plot_2D_uvq_packed(tmp_path):
 
 
 def test_grid_coords_odd_fail():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="Image must have an even number of pixels."):
         coordinates.GridCoords(cell_size=0.01, npix=511)
 
 
 def test_grid_coords_neg_cell_size():
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="cell_size must be a positive real number."):
         coordinates.GridCoords(cell_size=-0.01, npix=512)
 
 
@@ -99,5 +100,5 @@ def test_grid_coords_fail(mock_visibility_data):
     print("max u data", np.max(uu))
     print("max u grid", coords.max_grid)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(CellSizeError):
         coords.check_data_fit(uu, vv)

--- a/test/gridder_dataset_export_test.py
+++ b/test/gridder_dataset_export_test.py
@@ -10,7 +10,7 @@ from mpol.constants import *
 def gridder(mock_visibility_data):
     uu, vv, weight, data_re, data_im = mock_visibility_data
 
-    return gridding.Gridder(
+    return gridding.Gridder.from_image_properties(
         cell_size=0.005,
         npix=800,
         uu=uu,

--- a/test/gridder_gridding_test.py
+++ b/test/gridder_gridding_test.py
@@ -14,7 +14,7 @@ def test_grid_cont(mock_visibility_data_cont):
     """
     uu, vv, weight, data_re, data_im = mock_visibility_data_cont
 
-    gridder = gridding.Gridder(
+    gridder = gridding.Gridder.from_image_properties(
         cell_size=0.005,
         npix=800,
         uu=uu,
@@ -102,7 +102,7 @@ def test_weight_gridding(mock_visibility_data):
     data_re = np.ones_like(uu)
     data_im = np.ones_like(uu)
 
-    gridder = gridding.Gridder(
+    gridder = gridding.Gridder.from_image_properties(
         cell_size=0.005,
         npix=800,
         uu=uu,

--- a/test/gridder_imager_test.py
+++ b/test/gridder_imager_test.py
@@ -14,7 +14,7 @@ from mpol.constants import *
 def gridder(mock_visibility_data):
     uu, vv, weight, data_re, data_im = mock_visibility_data
 
-    return gridding.Gridder(
+    return gridding.Gridder.from_image_properties(
         cell_size=0.005,
         npix=800,
         uu=uu,
@@ -122,7 +122,6 @@ def test_beam_area_before_beam(gridder):
 
 # compare uniform and robust = -2.0
 def test_grid_uniform(gridder, tmp_path):
-
     kw = {"origin": "lower", "interpolation": "none", "extent": gridder.coords.img_ext}
 
     chan = 4
@@ -165,7 +164,6 @@ def test_grid_uniform(gridder, tmp_path):
 
 # compare uniform and robust = -2.0
 def test_grid_uniform_arcsec2(gridder, tmp_path):
-
     kw = {"origin": "lower", "interpolation": "none", "extent": gridder.coords.img_ext}
 
     chan = 4
@@ -208,7 +206,6 @@ def test_grid_uniform_arcsec2(gridder, tmp_path):
 
 
 def test_grid_natural(gridder, tmp_path):
-
     kw = {"origin": "lower", "interpolation": "none", "extent": gridder.coords.img_ext}
 
     chan = 4
@@ -250,7 +247,6 @@ def test_grid_natural(gridder, tmp_path):
 
 
 def test_grid_natural_arcsec2(gridder, tmp_path):
-
     kw = {"origin": "lower", "interpolation": "none", "extent": gridder.coords.img_ext}
 
     chan = 4

--- a/test/gridder_init_test.py
+++ b/test/gridder_init_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from mpol import coordinates, gridding
 from mpol.constants import *
+from mpol.exceptions import CellSizeError
 
 
 def test_hermitian_pairs(mock_visibility_data):
@@ -26,7 +27,7 @@ def test_hermitian_pairs(mock_visibility_data):
 def test_gridder_instantiate_cell_npix(mock_visibility_data):
     uu, vv, weight, data_re, data_im = mock_visibility_data
 
-    gridding.Gridder(
+    gridding.Gridder.from_image_properties(
         cell_size=0.005,
         npix=800,
         uu=uu,
@@ -52,30 +53,12 @@ def test_gridder_instantiate_gridCoord(mock_visibility_data):
     )
 
 
-def test_gridder_instantiate_npix_gridCoord_conflict(mock_visibility_data):
-    uu, vv, weight, data_re, data_im = mock_visibility_data
-
-    mycoords = coordinates.GridCoords(cell_size=0.005, npix=800)
-
-    with pytest.raises(AssertionError):
-        gridding.Gridder(
-            cell_size=0.005,
-            npix=800,
-            coords=mycoords,
-            uu=uu,
-            vv=vv,
-            weight=weight,
-            data_re=data_re,
-            data_im=data_im,
-        )
-
-
 def test_gridder_instantiate_bounds_fail(mock_visibility_data):
     uu, vv, weight, data_re, data_im = mock_visibility_data
 
     mycoords = coordinates.GridCoords(cell_size=0.05, npix=800)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(CellSizeError):
         gridding.Gridder(
             coords=mycoords,
             uu=uu,

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -8,34 +8,37 @@ from mpol.constants import *
 
 
 def test_odd_npix():
-    with pytest.raises(AssertionError):
-        images.BaseCube(npix=853, nchan=30, cell_size=0.015)
+    expected_error_message = "Image must have an even number of pixels."
 
-    with pytest.raises(AssertionError):
-        images.ImageCube(npix=853, nchan=30, cell_size=0.015)
+    with pytest.raises(ValueError, match=expected_error_message):
+        images.BaseCube.from_image_properties(npix=853, nchan=30, cell_size=0.015)
+
+    with pytest.raises(ValueError, match=expected_error_message):
+        images.ImageCube.from_image_properteis(npix=853, nchan=30, cell_size=0.015)
 
 
 def test_negative_cell_size():
-    with pytest.raises(AssertionError):
-        images.BaseCube(npix=800, nchan=30, cell_size=-0.015)
+    expected_error_message = "cell_size must be a positive real number."
 
-    with pytest.raises(AssertionError):
-        images.ImageCube(npix=800, nchan=30, cell_size=-0.015)
+    with pytest.raises(ValueError, match=expected_error_message):
+        images.BaseCube.from_image_properties(npix=800, nchan=30, cell_size=-0.015)
+
+    with pytest.raises(ValueError, match=expected_error_message):
+        images.ImageCube.from_image_properteis(npix=800, nchan=30, cell_size=-0.015)
 
 
 def test_single_chan():
-    im = images.ImageCube(cell_size=0.015, npix=800)
+    im = images.ImageCube.from_image_properteis(cell_size=0.015, npix=800)
     assert im.nchan == 1
 
 
 def test_basecube_grad():
-    bcube = images.BaseCube(npix=800, cell_size=0.015)
+    bcube = images.BaseCube.from_image_properties(npix=800, cell_size=0.015)
     loss = torch.sum(bcube.forward())
     loss.backward()
 
 
 def test_imagecube_grad(coords):
-
     bcube = images.BaseCube(coords=coords)
     # try passing through ImageLayer
     imagecube = images.ImageCube(coords=coords, passthrough=True)
@@ -69,7 +72,6 @@ def test_imagecube_tofits(coords, tmp_path):
 
 
 def test_basecube_imagecube(coords, tmp_path):
-
     # create a mock cube that includes negative values
     nchan = 1
     mean = torch.full(


### PR DESCRIPTION
Classes that either take in a `coords: GridCoords` object or a `cell_size: float` and `npix: int` values used the `_setup_coord` method from coordinates.py. These classes have been edited to each have their own class methods for different ways of instantiating itself. 

The new change is such that the `__init__` method accepts only `coord: GridCoord` objects. It is still possible to initialize from `cell_size` and `npix` values via: `ClassName.from_image_properties(cell_size, npix, **kwargs)`