### PR TITLE
Trigger GitHub actions on PR from fork

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [review_requested, closed]
     branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened, review_requested]
 
 # Prevent multiple PRs from building/deploying the docs at the same time
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: package test
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   dl_files:


### PR DESCRIPTION
When a PR is opened from a fork, the event `pull_request` won't trigger a github action workflow. Meanwhile, having both `pull_request` and `push` as events will cause the workflow to run twice on a push to a PR originating from within the repo (i.e. not from a fork). The event `pull_request_target` will run on a PR from a forked repo, and it will prevent running the tests twice otherwise. PR applies this change for `tests.yml` and `docs_build.yml`.