### PR TITLE
pre-release.yml: move linter after mpol install

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
+      - name: Install vanilla package
+        run: |
+          pip install .
+      - name: Install test deps
+        run: |
+          pip install .[test]
       - name: Lint with flake8
         run: |
           pip install flake8
@@ -55,12 +61,6 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Install vanilla package
-        run: |
-          pip install .
-      - name: Install test deps
-        run: |
-          pip install .[test]
       - name: Cache/Restore the .mpol folder cache
         uses: actions/cache@v3
         env:


### PR DESCRIPTION
Same fix as #130 (which was for `tests.yml`), but there I didn't think to check that the workflow order should also change in `pre-release.yml`. 

Note: all CI tests are running twice until #138 is merged.