### PR TITLE
Python versions for setup.py and workflows

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [review_requested, closed]
     branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened, review_requested]
 
 # Prevent multiple PRs from building/deploying the docs at the same time
 concurrency:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-20.04, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: package test
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   dl_files:

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
- updates `pre-release` workflow to no longer run on python 3.6, 3.7; to additionally run on 3.11
- updates `test` workflow to additionally run on 3.11 