### PR TITLE
GriddedDataset: torch warn fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,8 @@ name: package test
 
 on:
   pull_request_target:
-    paths:
-      - '*.*'
+    types: [opened, synchronize, reopened]
   push:
-    branches: ['main']
 
 jobs:
   dl_files:

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -101,10 +101,7 @@ class GriddedDataset:
             device (torch.device) : the desired device of the dataset. If ``None``, defalts to current device.
         """
 
-        if torch.is_tensor(mask):
-            new_2D_mask = mask.clone().detach().to(device)
-        else:
-            new_2D_mask = torch.tensor(mask, device=device)
+        new_2D_mask = torch.Tensor(mask).detach().to(device)
         new_3D_mask = torch.broadcast_to(new_2D_mask, self.mask.size())
 
         # update mask via an AND operation, meaning we will only keep visibilities that are

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -101,7 +101,10 @@ class GriddedDataset:
             device (torch.device) : the desired device of the dataset. If ``None``, defalts to current device.
         """
 
-        new_2D_mask = torch.tensor(mask, device=device)
+        if torch.is_tensor(mask):
+            new_2D_mask = mask.clone().detach().to(device)
+        else:
+            new_2D_mask = torch.tensor(mask, device=device)
         new_3D_mask = torch.broadcast_to(new_2D_mask, self.mask.size())
 
         # update mask via an AND operation, meaning we will only keep visibilities that are


### PR DESCRIPTION
Resolves a warning raised when passing a tensor to `GriddedDataset.add_mask`