### PR TITLE
Faster histograms

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,6 @@ ignore_missing_imports = True
 
 [mypy-torchkbnufft.*]
 ignore_missing_imports = True
+
+[mypy-fast_histogram.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
     url="https://github.com/iancze/MPoL",
     install_requires=[
         "numpy",
+        "fast-histogram",
         "scipy",
         "torch>=1.8.0",
         "torchvision",

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import warnings
 
 import numpy as np
+from fast_histogram import histogram as fast_hist
 
 from mpol.coordinates import GridCoords
-from mpol.exceptions import (DataError, ThresholdExceededError,
-                             WrongDimensionError)
+from mpol.exceptions import DataError, ThresholdExceededError, WrongDimensionError
 
 from .datasets import GriddedDataset
 
@@ -246,15 +246,16 @@ class GridderBase:
             A 2D array of size ``(npix, npix)`` in ground format containing the summed cell quantities.
         """
 
-        result = np.histogram2d(
+        result = fast_hist.histogram2d(
             vv,
             uu,
-            bins=[self.coords.v_edges, self.coords.u_edges],
+            bins=self.coords.ncell_u,
+            range=np.reshape(self.coords.vis_ext, (2, 2)),
             weights=values,
         )
 
         # only return the "H" value
-        return result[0]
+        return result
 
     def _sum_cell_values_cube(self, values=None):
         r"""

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -246,12 +246,14 @@ class GridderBase:
             A 2D array of size ``(npix, npix)`` in ground format containing the summed cell quantities.
         """
 
-        bin_range = self.coords.vis_ext[:2]
         result = fast_hist.histogram2d(
             vv,
             uu,
             bins=self.coords.ncell_u,
-            range=[bin_range, bin_range],
+            range=[
+                [self.coords.v_bin_min, self.coords.v_bin_max],
+                [self.coords.u_bin_min, self.coords.u_bin_max],
+            ],
             weights=values,
         )
 

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -246,11 +246,12 @@ class GridderBase:
             A 2D array of size ``(npix, npix)`` in ground format containing the summed cell quantities.
         """
 
+        bin_range = self.coords.vis_ext[:2]
         result = fast_hist.histogram2d(
             vv,
             uu,
             bins=self.coords.ncell_u,
-            range=np.reshape(self.coords.vis_ext, (2, 2)),
+            range=[bin_range, bin_range],
             weights=values,
         )
 


### PR DESCRIPTION
I benchmarked a small part of the code base and found that the `np.histogram2d` call in `_sum_cell_values_channel` method is pretty slow. The method takes up almost 75% of the entire running time (22.2 s / 29.6 s). See the visualized profiling below with the relevant section highlighted in magenta.
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/23248101/222869358-463ead5a-c4c8-4bd4-838b-6f0ed8eba755.png">
Since our gridding process creates grids that are uniformly spaced, we can opt for libraries that specialize in histograms for uniform bin sizes. I added `fast-histogram` into project's dependency and substituted the histogram call. The method call now only takes 6.2% of the total running time (0.565 s / 9.12 s) resulting in a 3.25x speed up. Relevant section highlighted again in magenta below.
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/23248101/222869775-fb14f718-aa00-40d6-b964-7009263f7aa5.png">