### PR TITLE
`fourier.py` type hinted

### DIFF
--- a/src/mpol/exceptions.py
+++ b/src/mpol/exceptions.py
@@ -13,5 +13,9 @@ class DataError(Exception):
     ...
 
 
+class DimensionMismatchError(Exception):
+    ...
+
+
 class ThresholdExceededError(Exception):
     ...

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -2,10 +2,14 @@ r"""The ``fourier`` module provides the core functionality of MPoL via :class:`m
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
 import torchkbnufft
+from numpy import floating, integer
+from numpy.typing import ArrayLike, NDArray
 from torch import nn
 
 from . import utils
@@ -103,7 +107,13 @@ class FourierCube(nn.Module):
         return torch.angle(self.ground_vis)
 
 
-def safe_baseline_constant_meters(uu, vv, freqs, coords, uv_cell_frac=0.05):
+def safe_baseline_constant_meters(
+    uu: NDArray[floating[Any]],
+    vv: NDArray[floating[Any]],
+    freqs: NDArray[floating[Any]],
+    coords: GridCoords,
+    uv_cell_frac: float = 0.05,
+) -> bool:
     r"""
     This routine determines whether the baselines can safely be assumed to be constant with channel when they converted from meters to units of kilolambda.
 
@@ -151,7 +161,12 @@ def safe_baseline_constant_meters(uu, vv, freqs, coords, uv_cell_frac=0.05):
     return max_diff < delta_uv
 
 
-def safe_baseline_constant_kilolambda(uu, vv, coords, uv_cell_frac=0.05):
+def safe_baseline_constant_kilolambda(
+    uu: NDArray[floating[Any]],
+    vv: NDArray[floating[Any]],
+    coords: GridCoords,
+    uv_cell_frac: float = 0.05,
+) -> bool:
     r"""
     This routine determines whether the baselines can safely be assumed to be constant with channel, when the are represented in units of kilolambda.
 

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -159,7 +159,7 @@ def safe_baseline_constant_meters(
     uv_diff = uv_max - uv_min
 
     # find maximum of that
-    max_diff = uv_diff.max()
+    max_diff: float = uv_diff.max()
 
     # compare to uv_cell_frac
     return max_diff < delta_uv
@@ -202,7 +202,7 @@ def safe_baseline_constant_kilolambda(
     uv_diff = uv_max - uv_min
 
     # find maximum of that
-    max_diff = uv_diff.max()
+    max_diff: float = uv_diff.max()
 
     # compare to uv_cell_frac
     return max_diff < delta_uv
@@ -434,7 +434,7 @@ class NuFFT(nn.Module):
         expanded = complexed.unsqueeze(altered_dimension)
 
         # torchkbnufft uses a [nbatch, ncoil, npix, npix] scheme
-        output = self.coords.cell_size**2 * self.nufft_ob(
+        output: torch.Tensor = self.coords.cell_size**2 * self.nufft_ob(
             expanded,
             self.k_traj,
             interp_mats=(
@@ -455,7 +455,7 @@ def make_fake_data(
     uu: NDArray[floating[Any]],
     vv: NDArray[floating[Any]],
     weight: NDArray[floating[Any]],
-) -> tuple[NDArray[floating[Any]], ...]:
+) -> tuple[NDArray[complexfloating[Any, Any]], ...]:
     r"""
     Create a fake dataset from a supplied :class:`mpol.images.ImageCube`. See :ref:`mock-dataset-label` for more details on how to prepare a generic image for use in an :class:`~mpol.images.ImageCube`.
 
@@ -482,6 +482,7 @@ def make_fake_data(
         weight = np.atleast_2d(weight)
 
     # carry it forward to the visibilities, which will be (nchan, nvis)
+    vis_noiseless: NDArray[complexfloating[Any, Any]]
     vis_noiseless = nufft(image_cube()).detach().numpy()
 
     # generate complex noise
@@ -531,6 +532,7 @@ def get_vis_residuals(
     # convert to numpy, select channel
     vis_model = vis_model.detach().numpy()[channel]
 
+    vis_resid: NDArray[complexfloating[Any, Any]]
     vis_resid = V_true - vis_model
 
     return vis_resid

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -251,11 +251,15 @@ class NuFFT(nn.Module):
     ):
         super().__init__()
 
-        if not (same_uv := uu.ndim == 1 and vv.ndim == 1):
+        if not (same_uv := uu.ndim == 1 and vv.ndim == 1) and sparse_matrices:
             import warnings
 
             warnings.warn(
-                "Provided uu and vv arrays are multi-dimensional, suggesting an intent to parallelize using the 'batch' dimension. This feature is not yet available in TorchKbNuFFT v1.4.0 with sparse matrix interpolation (sparse_matrices=True), therefore we are proceeding with table interpolation (sparse_matrices=False).",
+                "Provided uu and vv arrays are multi-dimensional, suggesting an "
+                "intent to parallelize using the 'batch' dimension. This feature "
+                "is not yet available in TorchKbNuFFT v1.4.0 with sparse matrix "
+                "interpolation (sparse_matrices=True), therefore we are proceeding "
+                "with table interpolation (sparse_matrices=False).",
                 category=RuntimeWarning,
             )
             sparse_matrices = False

--- a/src/mpol/protocols.py
+++ b/src/mpol/protocols.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+import mpol.coordinates
+import mpol.fourier
+import mpol.images
+
+
+class MPoLModel(Protocol):
+    coords: mpol.coordinates.GridCoords
+    nchan: int
+    bcube: mpol.images.BaseCube
+    icube: mpol.images.ImageCube
+    fcube: mpol.fourier.FourierCube
+
+    def forward(self):
+        ...


### PR DESCRIPTION
The module is fully type hinted now. I also simplified certain logic, mostly where branching can be removed. The logic changes are in the NUFFT `__init__`, `forward`, and `_assemble_ktraj` method.