### PR TITLE
Triggering tests on pull request

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -5,8 +5,6 @@ name: docs test
 on:
   pull_request:
     types: [review_requested, closed]
-  pull_request_target:
-    types: [review_requested, closed]
 
 # Prevent multiple PRs from building/deploying the docs at the same time
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,7 @@
 name: package test
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-  push:
+  pull_request:
 
 jobs:
   dl_files:


### PR DESCRIPTION
Updates `tests` and `docs_build` github actions to only run on `pull_request` -- this _should_ ensure tests run on branches of the main repo and on PRs from forks. It should also ensure tests only run once per PR event.