### PR TITLE
Redesigned GriddedDataset to inherit from `nn.Module`

### DIFF
--- a/docs/large-tutorials/pyro.md
+++ b/docs/large-tutorials/pyro.md
@@ -248,7 +248,6 @@ import torch
 from torch import nn
 from mpol import geometry, gridding, images, fourier, utils
 from mpol.constants import deg
-from mpol.datasets import index_vis
 
 import pyro
 import pyro.distributions as dist
@@ -605,10 +604,10 @@ class VisibilityModel(PyroModule):
             # evaluate the likelihood
             
             # use the FourierCube layer to get a gridded model
-            full_vis = self.flayer(img)
+            modelVisibilityCube = self.flayer(img)
 
             # extract the model visibilities corresponding to the gridded data
-            vis = index_vis(full_vis, self.dataset).flatten()
+            vis = self.dataset(modelVisibilityCube).flatten()
 
             with pyro.plate("data", len(self.data_re)):
                 # condition on the real and imaginaries of the data independently

--- a/docs/large-tutorials/pyro.md
+++ b/docs/large-tutorials/pyro.md
@@ -558,15 +558,13 @@ class VisibilityModel(PyroModule):
             data_im=np.imag(data),
         )
         
-        dset = averager.to_pytorch_dataset()
+        self.dataset = averager.to_pytorch_dataset()
         
         # extract relevant quantities
-        self.data_re = torch.as_tensor(np.real(dset.vis_indexed).flatten(), device=device)
-        self.data_im = torch.as_tensor(np.imag(dset.vis_indexed).flatten(), device=device)
-        self.sigma = torch.as_tensor(np.sqrt(1 / dset.weight_indexed).flatten(), device=device)
-
-        self.dataset = dset.to(device)
-
+        self.data_re = torch.as_tensor(np.real(self.dataset.vis_indexed).flatten(), device=device)
+        self.data_im = torch.as_tensor(np.imag(self.dataset.vis_indexed).flatten(), device=device)
+        self.sigma = torch.as_tensor(np.sqrt(1 / self.dataset.weight_indexed).flatten(), device=device)
+        
         # objects for forward loop
         self.icube = images.ImageCube(
             coords=self.coords, nchan=self.nchan, passthrough=True

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -139,7 +139,7 @@ class CrossValidate:
 
         Parameters
         ----------
-        dataset : PyTorch dataset object
+        dataset : dataset object
             Instance of the `mpol.datasets.GriddedDataset` class
         Returns
         -------

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -16,6 +16,7 @@ from . import spheroidal_gridding, utils
 from .constants import *
 from .utils import loglinspace
 
+
 class GriddedDataset(torch.nn.Module):
     r"""
     Args:
@@ -41,23 +42,28 @@ class GriddedDataset(torch.nn.Module):
         vis_gridded: torch.Tensor,
         weight_gridded: torch.Tensor,
         mask: torch.Tensor,
-        nchan: int = 1
+        nchan: int = 1,
     ) -> None:
         super().__init__()
 
         self.coords = coords
         self.nchan = nchan
 
-        # store variables as buffers of the module 
+        # store variables as buffers of the module
         self.register_buffer("vis_gridded", torch.tensor(vis_gridded))
         self.register_buffer("weight_gridded", torch.tensor(weight_gridded))
         self.register_buffer("mask", torch.tensor(mask))
+        self.vis_gridded: torch.Tensor
+        self.weight_gridded: torch.Tensor
+        self.mask: torch.Tensor
 
         # pre-index the values
         # note that these are *collapsed* across all channels
         # 1D array
-        self.register_buffer("vis_indexed" , self.vis_gridded[self.mask])
+        self.register_buffer("vis_indexed", self.vis_gridded[self.mask])
         self.register_buffer("weight_indexed", self.weight_gridded[self.mask])
+        self.vis_indexed: torch.Tensor
+        self.weight_indexed: torch.Tensor
 
     @classmethod
     def from_image_properties(
@@ -86,7 +92,7 @@ class GriddedDataset(torch.nn.Module):
             vis_gridded=vis_gridded,
             weight_gridded=weight_gridded,
             mask=mask,
-            nchan=nchan
+            nchan=nchan,
         )
 
     def add_mask(
@@ -97,7 +103,7 @@ class GriddedDataset(torch.nn.Module):
         Apply an additional mask to the data. Only works as a data limiting operation (i.e., ``mask`` is more restrictive than the mask already attached to the dataset).
 
         Args:
-            mask (2D numpy or PyTorch tensor): boolean mask (in packed format) to apply to dataset. Assumes input will be broadcast across all channels. 
+            mask (2D numpy or PyTorch tensor): boolean mask (in packed format) to apply to dataset. Assumes input will be broadcast across all channels.
         """
 
         new_2D_mask = torch.Tensor(mask).detach()
@@ -124,13 +130,13 @@ class GriddedDataset(torch.nn.Module):
         Args:
             modelVisibilityCube (complex torch.tensor): with shape ``(nchan, npix, npix)`` to be indexed. In "pre-packed" format, as in output from :meth:`mpol.fourier.FourierCube.forward()`
 
-        Returns: 
-            torch complex tensor:  1d torch tensor of indexed model samples collapsed across cube dimensions. 
+        Returns:
+            torch complex tensor:  1d torch tensor of indexed model samples collapsed across cube dimensions.
         """
 
         assert (
-                modelVisibilityCube.size()[0] == self.mask.size()[0]
-            ), "vis and dataset mask do not have the same number of channels."
+            modelVisibilityCube.size()[0] == self.mask.size()[0]
+        ), "vis and dataset mask do not have the same number of channels."
 
         # As of Pytorch 1.7.0, complex numbers are partially supported.
         # However, masked_select does not yet work (with gradients)

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -16,34 +16,6 @@ from . import spheroidal_gridding, utils
 from .constants import *
 from .utils import loglinspace
 
-
-def index_vis(vis, griddedDataset):
-    r"""
-    Index model visibilities to same locations as a :class:`~mpol.datasets.GriddedDataset`. Assumes that vis is "packed" just like the :class:`~mpol.datasets.GriddedDataset`
-
-    Args:
-        vis (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed."
-        griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
-
-    Returns:
-        torch complex tensor:  1d torch tensor of model samples collapsed across cube dimensions like ``vis_indexed`` and ``weight_indexed`` of :class:`~mpol.datasets.GriddedDataset`
-    """
-    assert (
-        vis.size()[0] == griddedDataset.mask.size()[0]
-    ), "vis and dataset mask do not have the same number of channels."
-
-    # As of Pytorch 1.7.0, complex numbers are partially supported.
-    # However, masked_select does not yet work (with gradients)
-    # on the complex vis, so hence this awkward step of selecting
-    # the reals and imaginaries separately
-    re = vis.real.masked_select(griddedDataset.mask)
-    im = vis.imag.masked_select(griddedDataset.mask)
-
-    # we had trouble returning things as re + 1.0j * im,
-    # but for some reason torch.complex seems to work OK.
-    return torch.complex(re, im)
-
-
 class GriddedDataset(torch.nn.Module):
     r"""
     Args:

--- a/src/mpol/losses.py
+++ b/src/mpol/losses.py
@@ -97,12 +97,12 @@ def nll(model_vis, data_vis, weight):
     return 1 / (2 * N) * chi_squared(model_vis, data_vis, weight)
 
 
-def chi_squared_gridded(vis, griddedDataset):
+def chi_squared_gridded(modelVisibilityCube, griddedDataset):
     r"""
     Calculate the :math:`\chi^2` (corresponding to :func:`~mpol.losses.chi_squared`) using gridded data and model visibilities.
 
     Args:
-        vis (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
+        modelVisibilityCube (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
         griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
 
     Returns:
@@ -110,24 +110,23 @@ def chi_squared_gridded(vis, griddedDataset):
 
     """
 
-    # use the index connector to get the model_visibilities from the dataset
+    # get the model_visibilities from the dataset
     # 1D torch tensor collapsed across cube dimensions, like
     # griddedDataset.vis_indexed and griddedDataset.weight_indexed
-    model_vis = datasets.index_vis(vis, griddedDataset)
-
-    model_vis = griddedDataset(vis)
+    
+    model_vis = griddedDataset(modelVisibilityCube)
 
     return chi_squared(
         model_vis, griddedDataset.vis_indexed, griddedDataset.weight_indexed
     )
 
 
-def log_likelihood_gridded(vis, griddedDataset):
+def log_likelihood_gridded(modelVisibilityCube, griddedDataset):
     r"""
     Calculate the log likelihood function :math:`\ln\mathcal{L}` (corresponding to :func:`~mpol.losses.log_likelihood`) using gridded data and model visibilities.
 
     Args:
-        vis (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
+        modelVisibilityCube (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
         griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
 
     Returns:
@@ -135,17 +134,17 @@ def log_likelihood_gridded(vis, griddedDataset):
 
     """
 
-    # use the index connector to get the model_visibilities from the dataset
+    # get the model_visibilities from the dataset
     # 1D torch tensor collapsed across cube dimensions, like
     # griddedDataset.vis_indexed and griddedDataset.weight_indexed
-    model_vis = datasets.index_vis(vis, griddedDataset)
+    model_vis = griddedDataset(modelVisibilityCube)
 
     return log_likelihood(
         model_vis, griddedDataset.vis_indexed, griddedDataset.weight_indexed
     )
 
 
-def nll_gridded(vis, datasetGridded):
+def nll_gridded(modelVisibilityCube, griddedDataset):
     r"""
     Calculate a normalized "negative log likelihood" (corresponding to :func:`~mpol.losses.nll`) using gridded data and model visibilities. Function will return the same value regardless of whether Hermitian pairs are included.
 
@@ -156,9 +155,9 @@ def nll_gridded(vis, datasetGridded):
     Returns:
         torch.double: the normalized negative log likelihood likelihood loss
     """
-    model_vis = datasets.index_vis(vis, datasetGridded)
+    model_vis = griddedDataset(modelVisibilityCube)
 
-    return nll(model_vis, datasetGridded.vis_indexed, datasetGridded.weight_indexed)
+    return nll(model_vis, griddedDataset.vis_indexed, griddedDataset.weight_indexed)
 
 
 def entropy(cube, prior_intensity, tot_flux=10):

--- a/src/mpol/losses.py
+++ b/src/mpol/losses.py
@@ -115,6 +115,8 @@ def chi_squared_gridded(vis, griddedDataset):
     # griddedDataset.vis_indexed and griddedDataset.weight_indexed
     model_vis = datasets.index_vis(vis, griddedDataset)
 
+    model_vis = griddedDataset(vis)
+
     return chi_squared(
         model_vis, griddedDataset.vis_indexed, griddedDataset.weight_indexed
     )

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -121,7 +121,7 @@ class TrainTest:
         ----------
         vis : torch.complex tensor
             Model visibility cube (see `mpol.fourier.FourierCube.forward`)
-        dataset : PyTorch dataset object
+        dataset : dataset object
             Instance of the `mpol.datasets.GriddedDataset` class.
         sky_cube : torch.double
             MPoL Ground Cube (see `mpol.utils.packed_cube_to_ground_cube`)

--- a/test/connectors_test.py
+++ b/test/connectors_test.py
@@ -6,7 +6,7 @@ from mpol import datasets, fourier, images
 from mpol.constants import *
 
 
-def test_index_vis(coords, dataset):
+def test_index(coords, dataset):
     # test that we can index a dataset
 
     flayer = fourier.FourierCube(coords=coords)
@@ -29,11 +29,11 @@ def test_index_vis(coords, dataset):
     # try passing through ImageLayer
     imagecube = images.ImageCube(coords=coords, nchan=nchan, passthrough=True)
 
-    # produce model visibilities
-    vis = flayer(imagecube(basecube()))
+    # produce dense model visibility cube
+    modelVisibilityCube = flayer(imagecube(basecube()))
 
     # take a basecube, imagecube, and GriddedDataset and predict corresponding visibilities.
-    datasets.index_vis(vis, dataset)
+    dataset(modelVisibilityCube)
 
 
 def test_connector_grad(coords, dataset):
@@ -45,8 +45,8 @@ def test_connector_grad(coords, dataset):
     imagecube = images.ImageCube(coords=coords, nchan=nchan, passthrough=True)
 
     # produce model visibilities
-    vis = flayer(imagecube(basecube()))
-    samples = datasets.index_vis(vis, dataset)
+    modelVisibilityCube = flayer(imagecube(basecube()))
+    samples = dataset(modelVisibilityCube)
 
     print(samples)
     loss = torch.sum(torch.abs(samples))


### PR DESCRIPTION
Implemented the changes we discussed during the hackday: 
* `GriddedDataset` now inherits from `nn.Module`
* We made this decision (as opposed to a `torch.utils.data.Dataset` inheritance) because we could then write a `forward` method to do the indexing
* This had the added benefit that we could move the `index_vis` method inside the forward method of the new `GriddedDataset`
* Minor updates to tutorials
* Seems to work with GPU transfer

Closes #163 