### PR TITLE
Single Zenodo record reference

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,11 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies needed to download files
-        # we're just installing the PyPI version of mpol here to reference the
-        # zenodo record number in __init__. below we'll reinstall the current 
-        # version of mpol for the tests below.
+        # we're just installing mpol here to reference the zenodo record number 
+        # in __init__. below we'll reinstall for the tests.
         run: |
           pip install astropy
-          pip install mpol
+          pip install .
       - name: Cache/Restore the .mpol folder cache
         uses: actions/cache@v3
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,12 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies needed to download files
+        # we're just installing the PyPI version of mpol here to reference the
+        # zenodo record number in __init__. below we'll reinstall the current 
+        # version of mpol for the tests below.
         run: |
           pip install astropy
+          pip install mpol
       - name: Cache/Restore the .mpol folder cache
         uses: actions/cache@v3
         env:

--- a/docs/ci-tutorials/crossvalidation.md
+++ b/docs/ci-tutorials/crossvalidation.md
@@ -48,10 +48,11 @@ from mpol import (
     losses,
     precomposed,
 )
+from mpol.__init__ import zenodo_record
 
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",
@@ -361,7 +362,7 @@ For the purposes of comparison, here is the image produced by the tclean algorit
 
 ```{code-cell}
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.tclean.fits",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.tclean.fits",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/ci-tutorials/fakedata.md
+++ b/docs/ci-tutorials/fakedata.md
@@ -271,10 +271,11 @@ Therefore, we always recommend generating fake data using $u,v$ distributions fr
 
 ```{code-cell} ipython3
 from astropy.utils.data import download_file
+from mpol.__init__ import zenodo_record
 
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/ci-tutorials/gridder.md
+++ b/docs/ci-tutorials/gridder.md
@@ -34,12 +34,13 @@ It's important to remember that MPoL follows the standard baseline convention as
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.utils.data import download_file
+from mpol.__init__ import zenodo_record
 ```
 
 ```{code-cell}
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/ci-tutorials/initializedirtyimage.md
+++ b/docs/ci-tutorials/initializedirtyimage.md
@@ -40,6 +40,7 @@ from astropy.utils.data import download_file
 
 ```{code-cell}
 from mpol import coordinates, gridding, losses, precomposed, utils
+from mpol.__init__ import zenodo_record
 ```
 
 When saving and loading a model, it is important to make sure that ``cell_size``, ``nchan``, and ``npix`` remain the same. More info on coordinates can be found in {class}`mpol.coordinates.GridCoords`.
@@ -47,7 +48,7 @@ When saving and loading a model, it is important to make sure that ``cell_size``
 ```{code-cell}
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/ci-tutorials/loose-visibilities.md
+++ b/docs/ci-tutorials/loose-visibilities.md
@@ -42,6 +42,7 @@ and the relevant MPoL modules
 
 ```{code-cell}
 from mpol import coordinates, gridding, losses, precomposed, utils, images, fourier
+from mpol.__init__ import zenodo_record
 ```
 
 and loading the dataset
@@ -49,7 +50,7 @@ and loading the dataset
 ```{code-cell}
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/ci-tutorials/optimization.md
+++ b/docs/ci-tutorials/optimization.md
@@ -35,12 +35,13 @@ from IPython.display import SVG, display
 
 ```{code-cell} ipython3
 from mpol import coordinates, fourier, gridding, losses, precomposed, utils
+from mpol.__init__ import zenodo_record
 ```
 
 ```{code-cell} ipython3
 # load the mock dataset of the ALMA logo
 fname = download_file(
-    "https://zenodo.org/record/10059491/files/logo_cube.noise.npz",
+    f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
     cache=True,
     show_progress=True,
     pkgname="mpol",

--- a/docs/download_external_files.py
+++ b/docs/download_external_files.py
@@ -1,6 +1,6 @@
 from astropy.utils.data import download_file
+from mpol.__init__ import zenodo_record
 
-version = 10059491
 slug = "https://zenodo.org/record/{:d}/files/{:}"
 
 fnames = [
@@ -10,7 +10,7 @@ fnames = [
 ]
 
 for fname in fnames:
-    url = slug.format(version, fname)
+    url = slug.format(zenodo_record, fname)
     download_file(
         url,
         cache=True,

--- a/src/mpol/__init__.py
+++ b/src/mpol/__init__.py
@@ -1,1 +1,2 @@
 __version__ = "0.1.13"
+zenodo_record = 10064221

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,7 @@ import pytest
 from astropy.utils.data import download_file
 
 from mpol import coordinates, gridding
-
-zenodo_version = 10059491
+from mpol.__init__ import zenodo_record
 
 # We need a fixture which provides mock visibilities of the sort we'd
 # expect from visread, but *without* the CASA dependency.
@@ -14,7 +13,7 @@ zenodo_version = 10059491
 def mock_visibility_archive():
     # use astropy routines to cache data
     fname = download_file(
-        "https://zenodo.org/record/{:d}/files/logo_cube.noise.npz".format(zenodo_version),
+        f"https://zenodo.org/record/{zenodo_record}/files/logo_cube.noise.npz",
         cache=True,
         pkgname="mpol",
     )


### PR DESCRIPTION
Reduces the number of hardcoded Zenodo record refernces in the codebase and docs to one, in `__init__`. 

Maybe changing `tests.yml` as I have is not ideal for the cache(?), but it's what I could think of to be able to reference anything in the codebase at that point in the workflow. 

Closes #194 