### PR TITLE
Add package test on push to main, update coverage badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: package test
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MPoL
 
-[![Tests](https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml/badge.svg)](https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml)
+[![Tests](https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml)
 [![gh-pages docs](https://github.com/MPoL-dev/MPoL/actions/workflows/gh_docs.yml/badge.svg)](https://mpol-dev.github.io/MPoL/)
 [![DOI](https://zenodo.org/badge/224543208.svg)](https://zenodo.org/badge/latestdoi/224543208)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Million Points of Light (MPoL)
 |Discussions badge|
 
 
-.. |Tests badge| image:: https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml/badge.svg
+.. |Tests badge| image:: https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml/badge.svg?branch=main
    :target: https://github.com/MPoL-dev/MPoL/actions/workflows/tests.yml
 
 .. |Discussions badge| image:: https://img.shields.io/badge/community-Github%20Discussions-orange


### PR DESCRIPTION
- Adds a trigger of `tests.yml` (the package test) for pushes to `main`. 
- Updates the `package test` badge in the readme and docs to show the status of the package test only on `main` (rather than the last time this test was run across all branches). 

Closes #196 