### PR TITLE
Train diagnostic figure update

### DIFF
--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -170,7 +170,7 @@ class CrossValidate:
         for kk, (train_set, test_set) in enumerate(split_iterator):
             if self._verbose:
                 logging.info(
-                    "\nCross-validation: k-fold {} of {}".format(kk, self._kfolds)
+                    "\nCross-validation: k-fold {} of {}".format(kk, self._kfolds - 1)
                 )
 
             # if hasattr(self._device,'type') and self._device.type == 'cuda': # TODO: confirm which objects need to be passed to gpu

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -235,33 +235,33 @@ class CrossValidate:
             "std": np.std(all_scores),
             "all": all_scores,
         }
-
+        
         return cv_score
-
+    
     @property
     def model(self):
-        """SimpleNet class instance"""
+        """For the most recent kfold, trained model (`SimpleNet` class instance)"""
         return self._model
 
     @property
     def regularizers(self):
-        """Dict containing regularizers used and their strengths"""
+        """For the most recent kfold, dict containing regularizers used and their strengths"""
         return self._regularizers
 
     @property
-    def diagnostics(self):
-        """Dict containing diagnostics of the cross-validation loop"""
-        return self._diagnostics
-
+    def train_figure(self):
+        """For the most recent kfold, (fig, axes) showing training progress"""
+        return self._train_figure
+        
     @property
     def split_figure(self):
         """(fig, axes) of train/test splitting diagnostic figure"""
         return self._split_figure
-
+    
     @property
-    def train_figure(self):
-        """(fig, axes) of most recent training diagnostic figure"""
-        return self._train_figure
+    def diagnostics(self):
+        """Dict containing diagnostics of the cross-validation loop across all kfolds: models, regularizers, loss values, training figures"""
+        return self._diagnostics
 
 
 class RandomCellSplitGridded:

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -219,15 +219,14 @@ class CrossValidate:
 
             # store objects from the most recent kfold for diagnostics           
             self._model = model
+            self._train_figure = trainer.train_figure
+
+            # collect objects from this kfold to store
             if self._store_cv_diagnostics:
-                self._diagnostics["loss_histories"].append(loss_history)   
-            # update regularizer strength values
-            self._regularizers = trainer.regularizers
-            # store the most recent train figure for diagnostics
-            self._train_figure = trainer.train_figure 
-            
-            # run testing
-            all_scores.append(trainer.test(self._model, test_set))
+                self._diagnostics["models"].append(self._model)
+                self._diagnostics["regularizers"].append(self._regularizers)
+                self._diagnostics["loss_histories"].append(loss_history)                
+                self._diagnostics["train_figures"].append(self._train_figure)
 
         # average individual test scores to get the cross-val metric for chosen
         # hyperparameters

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -351,22 +351,32 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old
     """
     Figure for model diagnostics during an optimization loop. For a `model` in 
     a given state, plots the current: 
-    - model image (both linear and arcsinh colormap normalization)
+    - model image
+    - flux of model image
     - gradient image
+    - difference image between `old_model_image` and current model image
     - loss function
+    - learning rate
 
     Parameters
     ----------
     model : `torch.nn.Module` object
-        A neural network; instance of the `mpol.precomposed.SimpleNet` class.
+        A neural network module; instance of the `mpol.precomposed.SimpleNet` class.
     losses : list
         Loss value at each epoch in the training loop
-    train_state : dict, default=None
-        Dictionary containing current training parameter values. Used for 
-        figure title and savefile name.
+    learn_rates : list
+        Learning rate at each epoch in the training loop  
+    fluxes : list
+        Total flux in model image at each epoch in the training loop
+    old_model_image : 2D image array, default=None
+        Model image of a previous epoch for comparison to current image        
+    kfold : int, default=None
+        Current cross-validation k-fold
+    epoch : int, default=None
+        Current training epoch
     channel : int, default=0
         Channel (of the datasets in `splitter`) to use to generate figure        
-    save_prefix : string, default = None
+    save_prefix : str, default = None
         Prefix for saved figure name. If None, the figure won't be saved
 
     Returns

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -376,9 +376,10 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
         Axes of the generated figure
     """
     fig, axes = plt.subplots(ncols=2, nrows=2, figsize=(8, 8))
+    axes[1][1].remove()
 
-    fig.suptitle(train_state)
-
+    fig.suptitle(f"Pixel size {model.coords.cell_size * 1e3:.2f} mas, Npix {model.coords.npix}\nk-fold {kfold}, epoch {epoch}", fontsize=10)
+    
     mod_im = torch2npy(model.icube.sky_cube[channel])
     mod_grad = torch2npy(packed_cube_to_sky_cube(model.bcube.base_cube.grad)[channel])
     extent = model.icube.coords.img_ext

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -345,8 +345,9 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
     return fig, axes
 
 
-def train_diagnostics_fig(model, losses=[], train_state=None, channel=0, 
-                        save_prefix=None):
+def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old_model_image=None,
+                          kfold=None, epoch=None,
+                          channel=0, save_prefix=None):
     """
     Figure for model diagnostics during an optimization loop. For a `model` in 
     a given state, plots the current: 
@@ -406,6 +407,7 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
         diff_im_norm = get_image_cmap_norm(diff_image, symmetric=True)
         plot_image(diff_image, extent, cmap='RdBu_r', ax=ax, xlab='', ylab='', norm=diff_im_norm)
         ax.set_title("Difference image", fontsize=10)
+        
     if losses is not None:
         # loss function
         ax = fig.add_subplot(426)

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -396,6 +396,17 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
 
     # gradient image
     ax = axes[1,0]
+    plot_image(mod_grad, extent, ax=ax)
+    ax.set_title("Gradient image", fontsize=10)
+
+    if old_model_image is not None:
+        # current model image - model image at last stored epoch
+        ax = axes[0,1]
+        diff_image = mod_im - old_model_image
+        diff_im_norm = get_image_cmap_norm(diff_image, symmetric=True)
+        plot_image(diff_image, extent, cmap='RdBu_r', ax=ax, xlab='', ylab='', norm=diff_im_norm)
+        ax.set_title("Difference image", fontsize=10)
+        
     if fluxes is not None:
         # total flux in model image 
         ax = fig.add_axes([0.08, 0.465, 0.3, 0.08])

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -405,7 +405,7 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
         ax.set_ylabel('Flux [Jy]', fontsize=8)
 
     if save_prefix is not None:
-        fig.savefig(save_prefix + '_train_diag_kfold{}_epoch{:05d}.png'.format(train_state["kfold"], train_state["epoch"]), dpi=300)
+        fig.savefig(save_prefix + f"_train_diag_kfold{kfold}_epoch{epoch:05d}.png", dpi=300)
     
     plt.close()
 

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -345,7 +345,8 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
     return fig, axes
 
 
-def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old_model_image=None,
+def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, 
+                          old_model_image=None, old_model_epoch=None,
                           kfold=None, epoch=None,
                           channel=0, save_prefix=None):
     """
@@ -369,7 +370,9 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old
     fluxes : list
         Total flux in model image at each epoch in the training loop
     old_model_image : 2D image array, default=None
-        Model image of a previous epoch for comparison to current image        
+        Model image of a previous epoch for comparison to current image  
+    old_model_epoch : int
+        Epoch of `old_model_image`
     kfold : int, default=None
         Current cross-validation k-fold
     epoch : int, default=None
@@ -389,7 +392,7 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old
     fig, axes = plt.subplots(ncols=2, nrows=2, figsize=(8, 8))
     axes[1][1].remove()
 
-    fig.suptitle(f"Pixel size {model.coords.cell_size * 1e3:.2f} mas, Npix {model.coords.npix}\nk-fold {kfold}, epoch {epoch}", fontsize=10)
+    fig.suptitle(f"Pixel size {model.coords.cell_size * 1e3:.2f} mas, N_pix {model.coords.npix}\nk-fold {kfold}, epoch {epoch}", fontsize=10)
     
     mod_im = torch2npy(model.icube.sky_cube[channel])
     mod_grad = torch2npy(packed_cube_to_sky_cube(model.bcube.base_cube.grad)[channel])
@@ -416,7 +419,7 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, old
         diff_image = mod_im - old_model_image
         diff_im_norm = get_image_cmap_norm(diff_image, symmetric=True)
         plot_image(diff_image, extent, cmap='RdBu_r', ax=ax, xlab='', ylab='', norm=diff_im_norm)
-        ax.set_title("Difference image", fontsize=10)
+        ax.set_title(f"Difference (epoch {epoch} - {old_model_epoch})", fontsize=10)
         
     if losses is not None:
         # loss function

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as mco 
+import torch 
 
 from astropy.visualization.mpl_normalize import simple_norm
 
@@ -49,7 +50,7 @@ def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetr
 
 
 def plot_image(image, extent, cmap="inferno", norm=None, ax=None, 
-               clab=r"Jy arcsec$^{-2}$",
+               clab=r"I [Jy arcsec$^{-2}$]",
                xlab=r"$\Delta \alpha \cos \delta$ [${}^{\prime\prime}$]",
                ylab=r"$\Delta \delta$ [${}^{\prime\prime}$]",
                ):
@@ -98,7 +99,7 @@ def plot_image(image, extent, cmap="inferno", norm=None, ax=None,
         norm=norm,
     )
 
-    cbar = plt.colorbar(im, ax=ax, location="right", pad=0.1)
+    cbar = plt.colorbar(im, ax=ax, location="right", pad=0.1, shrink=0.7)
     cbar.set_label(clab)
 
     ax.set_xlabel(xlab)

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -384,14 +384,14 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
     extent = model.icube.coords.img_ext
 
     # model image (linear colormap)
-    ax = axes[0,0]
-    plot_image(mod_im, extent, ax=ax, xlab='', ylab='')
-    ax.set_title("Model image")
+    # ax = axes[0,0]
+    # plot_image(mod_im, extent, ax=ax, xlab='', ylab='')
+    # ax.set_title("Model image")
 
     # model image (asinh colormap)
-    ax = axes[0,1]
-    plot_image(mod_im, extent, ax=ax, norm=get_image_cmap_norm(mod_im, stretch='asinh'))
-    ax.set_title("Model image (asinh stretch)")
+    ax = axes[0,0]
+    plot_image(mod_im, extent, ax=ax, xlab='', ylab='', norm=get_image_cmap_norm(mod_im, stretch='asinh'))
+    ax.set_title("Model image", fontsize=10)
 
     # gradient image
     ax = axes[1,0]

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -395,17 +395,14 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
 
     # gradient image
     ax = axes[1,0]
-    plot_image(mod_grad, extent, ax=ax, xlab='', ylab='')
-    ax.set_title("Gradient image")
-
-    # loss function
-    ax = axes[1,1]
-    ax.semilogy(losses, 'k')
-    ax.set_xlabel('Epoch')
-    ax.set_ylabel('Loss')
-    ax.set_title("Loss function")
-
-    fig.subplots_adjust(wspace=0.25)
+    if fluxes is not None:
+        # total flux in model image 
+        ax = fig.add_axes([0.08, 0.465, 0.3, 0.08])
+        ax.plot(fluxes, 'k', label=f"{fluxes[-1]:.4f}")
+        ax.legend(loc='upper right', fontsize=8)
+        ax.tick_params(labelsize=8)
+        # ax.set_xlabel('Epoch', fontsize=8)
+        ax.set_ylabel('Flux [Jy]', fontsize=8)
 
     if save_prefix is not None:
         fig.savefig(save_prefix + '_train_diag_kfold{}_epoch{:05d}.png'.format(train_state["kfold"], train_state["epoch"]), dpi=300)

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -406,7 +406,24 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
         diff_im_norm = get_image_cmap_norm(diff_image, symmetric=True)
         plot_image(diff_image, extent, cmap='RdBu_r', ax=ax, xlab='', ylab='', norm=diff_im_norm)
         ax.set_title("Difference image", fontsize=10)
-        
+    if losses is not None:
+        # loss function
+        ax = fig.add_subplot(426)
+        ax.semilogy(losses, 'k', label=f"{losses[-1]:.3f}")
+        ax.legend(loc='upper right')
+        ax.xaxis.set_tick_params(labelbottom=False)
+        ax.set_ylabel('Loss')
+
+    if learn_rates is not None:    
+        # learning rate
+        ax = fig.add_subplot(428)
+        ax.plot(learn_rates, 'k', label=f"{learn_rates[-1]:.3e}")
+        ax.legend(loc='upper right')
+        ax.set_xlabel('Epoch')
+        ax.set_ylabel('Learn rate')
+
+    plt.tight_layout()
+
     if fluxes is not None:
         # total flux in model image 
         ax = fig.add_axes([0.08, 0.465, 0.3, 0.08])

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -134,7 +134,10 @@ class TrainTest:
 
         The guesses update `lambda` values in `self._regularizers`.
         """
-
+        if self._verbose:
+            logging.info("    Updating regularizer strengths with automated "
+                         f"guessing. Initial values: {self._regularizers}")
+            
         # generate images of the data using two briggs robust values
         img1, _ = self._imager.get_dirty_image(weighting='briggs', robust=0.0)
         img2, _ = self._imager.get_dirty_image(weighting='briggs', robust=0.5)
@@ -170,6 +173,9 @@ class TrainTest:
             guess_TSV = 1 / (loss_TSV2 - loss_TSV1)
             self._regularizers['TSV']['lambda'] = guess_TSV.numpy().item()
 
+        if self._verbose:
+            logging.info(f"    Updated values: {self._regularizers}")
+                         
 
     def loss_eval(self, vis, dataset, sky_cube=None):
         r"""

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -312,9 +312,9 @@ class TrainTest:
                     )
                 self._train_figure = (train_fig, train_axes)
 
-            # temporarily store the current model image for use in next call to `train_diagnostics_fig`
-            old_mod_im = torch2npy(model.icube.sky_cube[0]) # TODO: support 'channel' (in TrainTest)
-            old_mod_epoch = count * 1
+                # temporarily store the current model image for use in next call to `train_diagnostics_fig`
+                old_mod_im = torch2npy(model.icube.sky_cube[0]) # TODO: support 'channel' (in TrainTest)
+                old_mod_epoch = count * 1
 
             count += 1
 

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -240,6 +240,7 @@ class TrainTest:
         fluxes = []
         losses = []
         learn_rates = []
+        old_mod_im = None
 
         # guess initial strengths for regularizers in `self._regularizers`
         # that have 'guess':True
@@ -304,6 +305,9 @@ class TrainTest:
                     save_prefix=self._save_prefix
                     )
                 self._train_figure = (train_fig, train_axes)
+
+            # temporarily store the current model image for use in next call to `train_diagnostics_fig`
+            old_mod_im = torch2npy(model.icube.sky_cube[0]) # TODO: support 'channel' (in TrainTest)
 
             count += 1
 

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -237,6 +237,7 @@ class TrainTest:
         model.train()
 
         count = 0
+        fluxes = []
         losses = []
         learn_rates = []
 
@@ -277,6 +278,10 @@ class TrainTest:
 
             # get predicted sky cube corresponding to model visibilities
             sky_cube = model.icube.sky_cube
+
+            # total flux in model image
+            total_flux = model.coords.cell_size ** 2 * torch.sum(sky_cube)
+            fluxes.append(torch2npy(total_flux))
 
             # calculate loss between model visibilities and data
             loss = self.loss_eval(vis, dataset, sky_cube)

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -4,6 +4,8 @@ import torch
 
 from mpol.losses import TSV, TV_image, entropy, nll_gridded, sparsity
 from mpol.plot import train_diagnostics_fig
+from mpol.utils import torch2npy
+
 def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):
     r"""
     Train against a dirty image of the observed visibilities using a loss function 
@@ -362,5 +364,4 @@ class TrainTest:
     @property
     def train_figure(self):
         """(fig, axes) of figure showing training diagnostics"""
-        return self._train_figure
         return self._train_figure

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -221,7 +221,7 @@ class TrainTest:
         Parameters
         ----------
         model : `torch.nn.Module` object
-            A neural network; instance of the `mpol.precomposed.SimpleNet` class.
+            A neural network module; instance of the `mpol.precomposed.SimpleNet` class.
         dataset : PyTorch dataset object
             Instance of the `mpol.datasets.GriddedDataset` class.
 
@@ -232,6 +232,7 @@ class TrainTest:
         losses : list of float
             Loss value at each iteration (epoch) in the loop
         """
+
         # set model to training mode
         model.train()
 
@@ -320,7 +321,7 @@ class TrainTest:
         Parameters
         ----------
         model : `torch.nn.Module` object
-            A neural network; instance of the `mpol.precomposed.SimpleNet` class.
+            A neural network module; instance of the `mpol.precomposed.SimpleNet` class.
         dataset : PyTorch dataset object
             Instance of the `mpol.datasets.GriddedDataset` class.
 
@@ -341,6 +342,7 @@ class TrainTest:
         # return loss value
         return loss.item()
 
+
     @property
     def regularizers(self):
         """Dict containing regularizers used and their strengths"""
@@ -350,8 +352,4 @@ class TrainTest:
     def train_figure(self):
         """(fig, axes) of figure showing training diagnostics"""
         return self._train_figure
-    
-    @property
-    def train_state(self):
-        """Dict containing parameters of interest in the training loop"""
-        return self._train_state
+        return self._train_figure

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -243,6 +243,7 @@ class TrainTest:
         losses = []
         learn_rates = []
         old_mod_im = None
+        old_mod_epoch = None
 
         # guess initial strengths for regularizers in `self._regularizers`
         # that have 'guess':True
@@ -305,6 +306,7 @@ class TrainTest:
                 train_fig, train_axes = train_diagnostics_fig(
                     model, losses=losses, learn_rates=learn_rates, fluxes=fluxes,
                     old_model_image=old_mod_im,
+                    old_model_epoch=old_mod_epoch,
                     kfold=self._kfold, epoch=count,
                     save_prefix=self._save_prefix
                     )
@@ -312,6 +314,7 @@ class TrainTest:
 
             # temporarily store the current model image for use in next call to `train_diagnostics_fig`
             old_mod_im = torch2npy(model.icube.sky_cube[0]) # TODO: support 'channel' (in TrainTest)
+            old_mod_epoch = count * 1
 
             count += 1
 

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -301,7 +301,9 @@ class TrainTest:
             # generate optional fit diagnostics
             if self._train_diag_step is not None and (count % self._train_diag_step == 0 or count == self._epochs or self.loss_convergence(np.array(losses))):
                 train_fig, train_axes = train_diagnostics_fig(
-                    model, losses=losses, train_state=self._train_state, 
+                    model, losses=losses, learn_rates=learn_rates, fluxes=fluxes,
+                    old_model_image=old_mod_im,
+                    kfold=self._kfold, epoch=count,
                     save_prefix=self._save_prefix
                     )
                 self._train_figure = (train_fig, train_axes)

--- a/test/train_test_test.py
+++ b/test/train_test_test.py
@@ -7,7 +7,7 @@ from torch.utils.tensorboard import SummaryWriter
 from mpol import losses, precomposed
 from mpol.plot import train_diagnostics_fig
 from mpol.training import TrainTest, train_to_dirty_image
-from mpol.constants import *
+from mpol.utils import torch2npy
 
 
 def test_traintestclass_training(coords, imager, dataset, generic_parameters):
@@ -83,8 +83,15 @@ def test_traintestclass_train_diagnostics_fig(coords, imager, dataset, generic_p
     trainer = TrainTest(imager=imager, optimizer=optimizer, **train_pars)
     loss, loss_history = trainer.train(model, dataset)
 
+    learn_rates = np.repeat(learn_rate, len(loss_history))
+
+    old_mod_im = torch2npy(model.icube.sky_cube[0])
+
     train_fig, train_axes = train_diagnostics_fig(model, 
                                                   losses=loss_history, 
+                                                  learn_rates=learn_rates,
+                                                  fluxes=np.zeros(len(loss_history)),
+                                                  old_model_image=old_mod_im
                                                   )
     train_fig.savefig(tmp_path / "train_diagnostics_fig.png", dpi=300)
     plt.close("all")


### PR DESCRIPTION
NOTE: This PR should only be reviewed after #207 and #206 are merged into `main` and `main` merged into this branch (it was branched from 207, which was branched from 206)

- Adds some new plots to the diagnostic figure that's generated at some chosen interval during a training loop:
    * difference image between model image at current iteration and that at the previous instance of the interval
    * flux of model image vs iteration
    * learning rate vs iteration
- Tracks model flux and learning rate in training loop
- Some general cleanup in the training and cross-val classes