### PR TITLE
Image comparison figure

### DIFF
--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -30,12 +30,9 @@ def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetr
         vmin = -vmax
 
     else:
-        vmax = image.max()
-
+        vmax, vmin = image.max(), image.min()
         if stretch == 'power':
             vmin = 0
-        elif stretch == 'asinh':     
-            vmin = max(0, image.min())
 
     if stretch == 'power':
         norm = mco.PowerNorm(gamma, vmin, vmax)    

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -579,7 +579,7 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
         if not any(xzoom) and not any(yzoom):
             beam_xy = (0.85 * xzoom[1], 0.85 * yzoom[0])
         else:
-            beam_xy = (0.85 * axes[1][0].get_xlim()[0], 0.85 * axes[1][0].get_ylim()[0])
+            beam_xy = (0.85 * axes[1][0].get_xlim()[1], 0.85 * axes[1][0].get_ylim()[0])
 
         beam_ellipse = Ellipse(xy=beam_xy,
                             width=clean_beam[0], 

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -1,12 +1,14 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as mco 
+from matplotlib.patches import Ellipse
 
 from astropy.visualization.mpl_normalize import simple_norm
 
 from mpol.fourier import get_vis_residuals
 from mpol.gridding import DirtyImager
 from mpol.utils import loglinspace, torch2npy, packed_cube_to_sky_cube
+from mpol.input_output import ProcessFitsImage
 
 def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetric=False):
     """

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -515,3 +515,21 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
         norm_dirty = get_image_cmap_norm(dirty_im, stretch='asinh')
         if clean_fits is not None:
             norm_clean = get_image_cmap_norm(clean_im, stretch='asinh')
+    
+    # plot MPoL model image
+    plot_image(mod_im, extent=model.icube.coords.img_ext,
+                    ax=axes[0][1], norm=norm_mod, xlab='', ylab='')
+
+    # plot imaged MPoL residual visibilities
+    plot_image(im_resid, extent=model.icube.coords.img_ext, 
+                ax=axes[1][1], norm=norm_resid, cmap='RdBu_r', xlab='', ylab='')
+
+    # plot dirty image
+    plot_image(dirty_im, extent=model.icube.coords.img_ext,  
+                    ax=axes[0][0], norm=norm_dirty)
+    
+    # plot clean image
+    if clean_fits is not None:
+        plot_image(clean_im, extent=clean_im_ext, 
+                    ax=axes[1][0], norm=norm_clean, xlab='', ylab='')
+        

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -547,3 +547,23 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
                             )
         axes[1][0].add_artist(beam_ellipse)
 
+    if not any(xzoom) and not any(yzoom):
+        for ii in [0,1]:
+            for jj in [0,1]:
+                axes[ii][jj].set_xlim(xzoom[1], xzoom[0])
+                axes[ii][jj].set_ylim(yzoom[0], yzoom[1])
+
+    axes[0][0].set_title(f"Dirty image (robust {robust})")
+    axes[0][1].set_title(f"MPoL image (flux {total_flux:.4f} Jy)")
+    if clean_fits is not None:
+        axes[1][0].set_title(f"Clean image (beam {clean_beam[0] * 1e3:.0f} $\\times$ {clean_beam[1] * 1e3:.0f} mas)")
+    axes[1][1].set_title(f"MPoL residual V imaged (robust {robust})")    
+
+    plt.tight_layout()
+
+    if save_prefix is not None:
+        fig.savefig(save_prefix + "_image_comparison.png", dpi=300)
+    
+    plt.close()
+
+    return fig, axes

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -533,3 +533,17 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
         plot_image(clean_im, extent=clean_im_ext, 
                     ax=axes[1][0], norm=norm_clean, xlab='', ylab='')
         
+        # add clean beam to plot
+        if not any(xzoom) and not any(yzoom):
+            beam_xy = (0.85 * xzoom[1], 0.85 * yzoom[0])
+        else:
+            beam_xy = (0.85 * axes[1][0].get_xlim()[0], 0.85 * axes[1][0].get_ylim()[0])
+
+        beam_ellipse = Ellipse(xy=beam_xy,
+                            width=clean_beam[0], 
+                            height=clean_beam[1], 
+                            angle=-clean_beam[2], 
+                            color='w'
+                            )
+        axes[1][0].add_artist(beam_ellipse)
+

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -475,6 +475,48 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
                          title="",
                          channel=0, 
                          save_prefix=None):
+    """
+    Figure for comparison of MPoL model image to other image models. Plots: 
+    - dirty image
+    - MPoL model image
+    - MPoL residual visibilities imaged
+    - clean image (if a .fits file is supplied)
+
+    Parameters
+    ----------
+    model : `torch.nn.Module` object
+        A neural network; instance of the `mpol.precomposed.SimpleNet` class.
+    u, v : array, unit=[k\lambda]
+        Data u- and v-coordinates
+    V : array, unit=[Jy]
+        Data visibility amplitudes
+    weights : array, unit=[Jy^-2]
+        Data weights        
+    robust : float, default=0.5
+        Robust weighting parameter used to create the dirty image of the 
+        observed visibilities and separately of the MPoL residual visibilities  
+    clean_fits : str, default=None
+        Path to a clean .fits image
+    share_cscale : bool, default=False
+        Whether the MPoL model image, dirty image and clean image share the 
+        same colorscale
+    xzoom, yzoom : list of float, default = [None, None]
+        X- and y- axis limits to zoom the images to. `xzoom` and `yzoom` should 
+        both list values in ascending order (e.g. [-2, 3], not [3, -2])
+    title : str, default=""
+        Figure super-title
+    channel : int, default=0
+        Channel of the model to use to generate figure        
+    save_prefix : string, default = None
+        Prefix for saved figure name. If None, the figure won't be saved
+
+    Returns
+    -------
+    fig : Matplotlib `.Figure` instance
+        The generated figure
+    axes : Matplotlib `~.axes.Axes` class
+        Axes of the generated figure
+    """
     fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10,10))
 
     if share_cscale:

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -79,8 +79,8 @@ def get_residual_image(model, u, v, V, weights, robust=0.5):
 
     resid_imager = DirtyImager(
         coords=model.coords,
-        uu=u / 1e3,
-        vv=v / 1e3,
+        uu=u,
+        vv=v,
         weight=weights,
         data_re=np.real(vis_resid),
         data_im=np.imag(vis_resid),
@@ -465,3 +465,12 @@ def train_diagnostics_fig(model, losses=[], train_state=None, channel=0,
     plt.close()
 
     return fig, axes
+
+
+def image_comparison_fig(model, u, v, V, weights, robust=0.5, 
+                         clean_fits=None, share_cscale=False, 
+                         xzoom=[None, None], yzoom=[None, None],
+                         title="",
+                         channel=0, 
+                         save_prefix=None):
+    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10,10))

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -4,3 +4,29 @@ from astropy.utils.data import download_file
 
 from mpol import precomposed
 from mpol.plot import image_comparison_fig
+
+def test_image_comparison_fig(coords, tmp_path):
+    # generate an image comparison figure
+
+    model = precomposed.SimpleNet(coords=coords, nchan=1)
+    model()
+
+    # just interested in whether the tested functionality runs
+    u = v = np.repeat(1e3, 1000)
+    V = weights = np.ones_like(u)
+
+    # .fits file to act as clean image
+    fname = download_file(
+        "https://zenodo.org/record/4711811/files/logo_cube.tclean.fits",
+        cache=True,
+        show_progress=True,
+        pkgname="mpol",
+    )
+
+    image_comparison_fig(model, u, v, V, weights, robust=0.5, 
+                            clean_fits=fname,
+                            share_cscale=False, 
+                            xzoom=[-2, 2], yzoom=[-2, 2],
+                            title="test",
+                            save_prefix=None,                            
+                            )    

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+from astropy.utils.data import download_file
+
+from mpol import precomposed
+from mpol.plot import image_comparison_fig


### PR DESCRIPTION
NOTE: This PR should only be reviewed after #209 and #210 are merged into `main` and `main` merged into this branch.

- Adds a function to generate a figure that compares an MPoL model image and its imaged residual visibilities to a dirty image and optionally a clean image (supplied as a `.fits`). 

- Adds a test of this function.