### PR TITLE
Dartboard: give train splits have short baseline data

### DIFF
--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -295,6 +295,8 @@ class RandomCellSplitGridded:
     Treats `dataset` as a single-channel object with all data in `channel`.
 
     The splitting doesn't select (preserve) Hermitian pairs of visibilities.
+
+    All train splits have the highest 1% of cells by gridded weight
     """
 
     def __init__(self, dataset, k=5, seed=None, channel=0):
@@ -392,6 +394,10 @@ class DartboardSplitGridded:
     >>> ... # do operations with train dataset
     >>> ... # do operations with test dataset
 
+    Notes:
+        All train splits have the cells belonging to the shortest dartboard baseline bin.
+
+        The number of points in the splits is in general not equal.
     """
 
     def __init__(

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -422,14 +422,21 @@ class DartboardSplitGridded:
         # create the full cell_list
         self.cell_list = self.dartboard.get_nonzero_cell_indices(qs, phis)
 
-        # partition the cell_list into k pieces
+        # indices of cells in the smallest q bin that also have data
+        small_q_idx = [i for i,l in enumerate(self.cell_list) if l[0] == 0]
+        # cells in the smallest q bin
+        self.small_q = self.cell_list[:len(small_q_idx)]
+
+        # partition the cell_list into k pieces.
         # first, randomly permute the sequence to make sure
-        # we don't get structured radial/azimuthal patterns
+        # we don't get structured radial/azimuthal patterns.
+        # also exclude the cells belonging to the smallest q bin from all splits
+        # (we'll add these only to the training splits, as they're iterated through)
         if seed is not None:
             np.random.seed(seed)
 
         self.k_split_cell_list = np.array_split(
-            np.random.permutation(self.cell_list), k
+            np.random.permutation(self.cell_list[len(small_q_idx):]), k
         )
 
     @classmethod

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -472,6 +472,8 @@ class DartboardSplitGridded:
 
             # put the remaining indices back into a full list
             cell_list_train = np.concatenate(k_list)
+            # add the smallest q bin cells into the train list
+            cell_list_train = np.append(cell_list_train, self.small_q, axis=0)
 
             # create the masks for each cell_list
             train_mask = self.dartboard.build_grid_mask_from_cells(cell_list_train)

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -156,6 +156,10 @@ class CrossValidate:
                 dataset, k=self._kfolds, dartboard=dartboard, seed=self._seed
             )
 
+            if self._verbose:
+                logging.info(f"    Max baseline in Fourier grid {self._coords.q_max} klambda")
+                logging.info(f"    Dartboard: baseline bin edges {dartboard.q_edges.tolist()} klambda")
+
         else:
             supported_methods = ["dartboard", "random_cell"]
             raise ValueError(

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -14,7 +14,7 @@ from mpol.datasets import Dartboard, GriddedDataset
 from mpol.precomposed import SimpleNet
 from mpol.training import TrainTest, train_to_dirty_image
 from mpol.plot import split_diagnostics_fig
-
+from mpol.utils import loglinspace
 
 class CrossValidate:
     r"""
@@ -55,8 +55,11 @@ class CrossValidate:
         diagnostics will be generated.
     kfolds : int, default=5
         Number of k-folds to use in cross-validation
-    split_method : str, default='random_cell'
-        Method to split full dataset into train/test subsets        
+    split_method : str, default='dartboard'
+        Method to split full dataset into train/test subsets
+    dartboard_q_edges, dartboard_phi_edges : list of float, default=None, unit=[klambda]
+        Radial and azimuthal bin edges of the cells used to split the dataset
+        if `split_method`==`dartboard` (see `datasets.Dartboard`)
     split_diag_fig : bool, default=False
         Whether to generate a diagnostic figure of dataset splitting into
         train/test sets.
@@ -78,7 +81,8 @@ class CrossValidate:
                 regularizers={}, epochs=10000, convergence_tol=1e-5, 
                 schedule_factor=0.995,
                 start_dirty_image=False, 
-                train_diag_step=None, kfolds=5, split_method="random_cell", 
+                train_diag_step=None, kfolds=5, split_method="dartboard",
+                dartboard_q_edges=None, dartboard_phi_edges=None,
                 split_diag_fig=False, store_cv_diagnostics=False, 
                 save_prefix=None, verbose=True, device=None, seed=None,
                 ):
@@ -93,6 +97,8 @@ class CrossValidate:
         self._train_diag_step = train_diag_step
         self._kfolds = kfolds
         self._split_method = split_method
+        self._dartboard_q_edges = dartboard_q_edges
+        self._dartboard_phi_edges = dartboard_phi_edges
         self._split_diag_fig = split_diag_fig
         self._store_cv_diagnostics = store_cv_diagnostics
         self._save_prefix = save_prefix

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -506,15 +506,7 @@ def make_fake_data(
     return vis_noise, vis_noiseless
 
 
-def get_vis_residuals(
-    model: MPoLModel,
-    u_true: NDArray[floating[Any]],
-    v_true: NDArray[floating[Any]],
-    V_true: NDArray[complexfloating[Any, Any]],
-    return_Vmod : bool = False,
-    channel: int = 0,
- ) -> tuple[NDArray[complexfloating[Any, Any]], NDArray[complexfloating[Any, Any]]]:
-
+def get_vis_residuals(model, u_true, v_true, V_true, return_Vmod=False, channel=0):
     r"""
     Use `mpol.fourier.NuFFT` to get residuals between gridded `model` and loose
     (ungridded) data visiblities at data (u, v) coordinates

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -513,7 +513,8 @@ def get_vis_residuals(
     V_true: NDArray[complexfloating[Any, Any]],
     return_Vmod : bool = False,
     channel: int = 0,
-) -> NDArray[complexfloating[Any, Any]]:
+ ) -> tuple[NDArray[complexfloating[Any, Any]], NDArray[complexfloating[Any, Any]]]:
+
     r"""
     Use `mpol.fourier.NuFFT` to get residuals between gridded `model` and loose
     (ungridded) data visiblities at data (u, v) coordinates

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -511,6 +511,7 @@ def get_vis_residuals(
     u_true: NDArray[floating[Any]],
     v_true: NDArray[floating[Any]],
     V_true: NDArray[complexfloating[Any, Any]],
+    return_Vmod : bool = False,
     channel: int = 0,
 ) -> NDArray[complexfloating[Any, Any]]:
     r"""
@@ -526,6 +527,9 @@ def get_vis_residuals(
         Data u- and v-coordinates
     V_true : array, unit=[Jy]
         Data visibility amplitudes
+    return_Vmod : bool, default=False
+        Whether to return just the residual visibilities, or additionally the 
+        loose model visibilities
     channel : int, default=0
         Channel (of `model`) to use to calculate residual visibilities
 
@@ -537,11 +541,13 @@ def get_vis_residuals(
     """
     nufft = NuFFT(coords=model.coords, nchan=model.nchan, uu=u_true, vv=v_true)
 
-    vis_model = nufft(model.icube())
+    vis_model = nufft(model.icube().to('cpu')) # TODO: remove 'to' call
     # convert to numpy, select channel
     vis_model = vis_model.detach().numpy()[channel]
 
-    vis_resid: NDArray[complexfloating[Any, Any]]
     vis_resid = V_true - vis_model
 
+    if return_Vmod:
+        return vis_resid, vis_model
+    
     return vis_resid

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -602,19 +602,19 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
         if clean_fits is not None:
             norm_clean = get_image_cmap_norm(clean_im, stretch='asinh')
     
-    # plot MPoL model image
+    # MPoL model image
     plot_image(mod_im, extent=model.icube.coords.img_ext,
                     ax=axes[0][1], norm=norm_mod, xlab='', ylab='')
 
-    # plot imaged MPoL residual visibilities
+    # imaged MPoL residual visibilities
     plot_image(im_resid, extent=model.icube.coords.img_ext, 
                 ax=axes[1][1], norm=norm_resid, cmap='RdBu_r', xlab='', ylab='')
 
-    # plot dirty image
+    # dirty image
     plot_image(dirty_im, extent=model.icube.coords.img_ext,  
                     ax=axes[0][0], norm=norm_dirty)
     
-    # plot clean image
+    # clean image
     if clean_fits is not None:
         plot_image(clean_im, extent=clean_im_ext, 
                     ax=axes[1][0], norm=norm_clean, xlab='', ylab='')

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -357,40 +357,42 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
     No assumption or correction is made concerning whether the (u,v) distances 
     are projected or deprojected.
     """
-    fig, axes = plt.subplots(nrows=splitter.k, ncols=2, figsize=(6, 10))
+    fig, axes = plt.subplots(nrows=2, ncols=splitter.k, figsize=(10,3))
+
+    kw = {"fontsize": 8}
+
+    fig.suptitle('Training data: black, test data: red', **kw)
 
     for ii, (train, test) in enumerate(splitter):
         train_mask = torch2npy(train.ground_mask[channel])
         test_mask = torch2npy(test.ground_mask[channel])
-        vis_ext = train.coords.vis_ext
+        vis_ext = np.divide(train.coords.vis_ext, 1e3)
 
         cmap_train = mco.ListedColormap(['none', 'black'])
         cmap_test = mco.ListedColormap(['none', 'red'])
 
-        axes[ii, 0].imshow(train_mask, origin="lower", extent=vis_ext, 
+        axes[0, ii].imshow(train_mask / 1e3, origin="lower", extent=vis_ext, 
             cmap=cmap_train, interpolation="none")      
-        axes[ii, 0].imshow(test_mask, origin="lower", extent=vis_ext, 
+        axes[0, ii].imshow(test_mask / 1e3, origin="lower", extent=vis_ext, 
             cmap=cmap_test, interpolation="none")     
-        axes[ii, 1].imshow(test_mask, origin="lower", extent=vis_ext, 
+        axes[1, ii].imshow(test_mask / 1e3, origin="lower", extent=vis_ext, 
             cmap=cmap_test, interpolation="none")            
 
-        axes[ii, 0].set_ylabel("k-fold {:}".format(ii))
-
-    axes[0, 0].set_title("Training set (black)\nTest set (red)")
-    axes[0, 1].set_title("Test set")
+        axes[0, ii].set_title(f"k-fold {ii}", **kw)
 
     for aa in axes.flatten()[:-1]:
+        aa.yaxis.set_ticks_position("both")
         aa.xaxis.set_ticklabels([])
         aa.yaxis.set_ticklabels([])
 
-    ax = axes[-1,1]
-    ax.set_xlabel(r'u [k$\lambda$]')
-    ax.set_ylabel(r'v [k$\lambda$]')
-    ax.yaxis.tick_right()
+    ax = axes[1,-1]
+    ax.set_xlabel(r'u [M$\lambda$]', **kw)
+    ax.set_ylabel(r'v [M$\lambda$]', **kw)
     ax.yaxis.set_ticks_position("both")
-    ax.yaxis.set_label_position("right")    
+    ax.yaxis.tick_right()    
+    ax.yaxis.set_label_position("right") 
 
-    fig.subplots_adjust(left=0.05, hspace=0.0, wspace=0.1, top=0.9, bottom=0.1)
+    fig.subplots_adjust(hspace=0.02, wspace=0, left=0.03, right=0.92, top=0.9, bottom=0.1)
 
     if save_prefix is not None:
         fig.savefig(save_prefix + '_split_diag.png', dpi=300)

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -561,6 +561,7 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
     """
     fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10,10))
 
+    title += f"\nMPoL pixel size {model.coords.cell_size * 1e3:.2f} mas, N_pix {model.coords.npix}"
     if share_cscale:
         title += "\nDirty and clean images use colorscale of MPoL image"
     fig.suptitle(title)

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -359,24 +359,22 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
     """
     fig, axes = plt.subplots(nrows=2, ncols=splitter.k, figsize=(10,3))
 
-    kw = {"fontsize": 8}
+    cmap_train = mco.ListedColormap(['none', 'black'])
+    cmap_test = mco.ListedColormap(['none', 'red'])
+    
+    kw = {"fontsize":8}
+    image_kw = {"origin":"lower", "interpolation":"none"}
 
     fig.suptitle('Training data: black, test data: red', **kw)
 
     for ii, (train, test) in enumerate(splitter):
         train_mask = torch2npy(train.ground_mask[channel])
         test_mask = torch2npy(test.ground_mask[channel])
-        vis_ext = np.divide(train.coords.vis_ext, 1e3)
+        vis_ext = np.array(train.coords.vis_ext) / 1e3
 
-        cmap_train = mco.ListedColormap(['none', 'black'])
-        cmap_test = mco.ListedColormap(['none', 'red'])
-
-        axes[0, ii].imshow(train_mask / 1e3, origin="lower", extent=vis_ext, 
-            cmap=cmap_train, interpolation="none")      
-        axes[0, ii].imshow(test_mask / 1e3, origin="lower", extent=vis_ext, 
-            cmap=cmap_test, interpolation="none")     
-        axes[1, ii].imshow(test_mask / 1e3, origin="lower", extent=vis_ext, 
-            cmap=cmap_test, interpolation="none")            
+        axes[0, ii].imshow(train_mask, extent=vis_ext, cmap=cmap_train, **image_kw)
+        axes[0, ii].imshow(test_mask, extent=vis_ext, cmap=cmap_test, **image_kw)
+        axes[1, ii].imshow(test_mask, extent=vis_ext, cmap=cmap_test, **image_kw)
 
         axes[0, ii].set_title(f"k-fold {ii}", **kw)
 

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -653,3 +653,5 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
     plt.close()
 
     return fig, axes
+
+    return fig, axes


### PR DESCRIPTION
- Alters `crossval.DartboardSplitGridded` to give every train split the cells belonging to the smallest baseline bin in the dartboard. Withholds these cells from all test sets. 
     - This resolves an issue in which the splitting can result in one k-fold performing quite different from the others (having an outlier loss function and CV score) because the split for that k-fold happened to put some of the smallest baseline cells in the test set. Thus it seems even missing some of the shortest baseline points can significantly affect the modeling.

- Sets the default `Dartboard` in `CrossValidate` to set `q` cells based on the max baseline in the data, not the max of the Fourier grid (which can be quite a bit larger). This ensures the points that every train cell gets aren't too large a fraction of the total vis distribution. I've set the `q` bins to be the same as in `vis_histogram_fig` so that the figure made by that corresponds to the splits in a cross-val loop by default (also added args to pass in `q` and `phi` bins to `CrossValidate`).

- Updates the figure produced by `plot.split_diagnostics_fig` to look a bit better