### PR TITLE
Dartboard: handle case for 1 k-fold

### DIFF
--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -252,7 +252,7 @@ class CrossValidate:
                 self._diagnostics["models"].append(self._model)
                 self._diagnostics["regularizers"].append(self._regularizers)
                 self._diagnostics["loss_histories"].append(loss_history)                
-                self._diagnostics["train_figures"].append(self._train_figure)
+                # self._diagnostics["train_figures"].append(self._train_figure)
 
         # average individual test scores to get the cross-val metric for chosen
         # hyperparameters
@@ -296,7 +296,7 @@ class CrossValidate:
     
     @property
     def diagnostics(self):
-        """Dict containing diagnostics of the cross-validation loop across all kfolds: models, regularizers, loss values, training figures"""
+        """Dict containing diagnostics of the cross-validation loop across all kfolds: models, regularizers, loss values"""
         return self._diagnostics
 
 
@@ -510,7 +510,14 @@ class DartboardSplitGridded:
     def __next__(self) -> tuple[GriddedDataset, GriddedDataset]:
         if self.n < self.k:
             k_list = self.k_split_cell_list.copy()
-            cell_list_test = k_list.pop(self.n)
+            if self.k == 1:
+                # number of cells ~equal to 20% of full cell list
+                ntest = round(0.2 * len(k_list[0]))
+                cell_list_test = k_list[0][:ntest]
+                # remove cells place in test set from train set
+                k_list[0] = np.delete(k_list[0], range(ntest), axis=0)
+            else:
+                cell_list_test = k_list.pop(self.n)
 
             # put the remaining indices back into a full list
             cell_list_train = np.concatenate(k_list)

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -442,6 +442,7 @@ class DartboardSplitGridded:
         k: int,
         dartboard: Dartboard | None = None,
         seed: int | None = None,
+        verbose: bool = True
     ):
         if k <= 0:
             raise ValueError("k must be a positive integer")
@@ -452,6 +453,7 @@ class DartboardSplitGridded:
         self.griddedDataset = gridded_dataset
         self.k = k
         self.dartboard = dartboard
+        self.verbose = verbose
 
         # 2D mask for any UV cells that contain visibilities
         # in *any* channel
@@ -489,6 +491,7 @@ class DartboardSplitGridded:
         q_edges: NDArray[floating[Any]],
         phi_edges: NDArray[floating[Any]],
         seed: int | None = None,
+        verbose: bool = True,
     ) -> DartboardSplitGridded:
         r"""
         Alternative method to initialize a DartboardSplitGridded object from Dartboard parameters.
@@ -499,9 +502,10 @@ class DartboardSplitGridded:
              q_edges (1D numpy array): an array of radial bin edges to set the dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults to 12 log-linearly radial bins stretching from 0 to the :math:`q_\mathrm{max}` represented by ``coords``.
              phi_edges (1D numpy array): an array of azimuthal bin edges to set the dartboard cells in [radians]. If ``None``, defaults to 8 equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
              seed (int): (optional) numpy random seed to use for the permutation, for reproducibility
+             verbose (bool): whether to print notification messages
         """
         dartboard = Dartboard(gridded_dataset.coords, q_edges, phi_edges)
-        return cls(gridded_dataset, k, dartboard, seed)
+        return cls(gridded_dataset, k, dartboard, seed, verbose)
 
     def __iter__(self) -> DartboardSplitGridded:
         self.n = 0  # the current k-slice we're on
@@ -511,6 +515,8 @@ class DartboardSplitGridded:
         if self.n < self.k:
             k_list = self.k_split_cell_list.copy()
             if self.k == 1:
+                if self.verbose is True:
+                    logging.info("    DartboardSplitGridded: only 1 k-fold: splitting dataset as ~80/20 train/test")
                 # number of cells ~equal to 20% of full cell list
                 ntest = round(0.2 * len(k_list[0]))
                 cell_list_test = k_list[0][:ntest]

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -517,10 +517,10 @@ class DartboardSplitGridded:
             if self.k == 1:
                 if self.verbose is True:
                     logging.info("    DartboardSplitGridded: only 1 k-fold: splitting dataset as ~80/20 train/test")
-                # number of cells ~equal to 20% of full cell list
                 ntest = round(0.2 * len(k_list[0]))
+                # put ~20% of cells into test set
                 cell_list_test = k_list[0][:ntest]
-                # remove cells place in test set from train set
+                # remove cells in test set from train set
                 k_list[0] = np.delete(k_list[0], range(ntest), axis=0)
             else:
                 cell_list_test = k_list.pop(self.n)

--- a/test/crossval_test.py
+++ b/test/crossval_test.py
@@ -21,6 +21,23 @@ def test_crossvalclass_split_dartboard(coords, imager, dataset, generic_paramete
     cross_validator = CrossValidate(coords, imager, **crossval_pars)
     cross_validator.split_dataset(dataset)
 
+def test_crossvalclass_split_dartboard_1kfold(coords, imager, dataset, generic_parameters):
+
+    crossval_pars = generic_parameters["crossval_pars"]
+    crossval_pars["split_method"] = "dartboard"
+    crossval_pars['kfolds'] = 1
+
+    cross_validator = CrossValidate(coords, imager, **crossval_pars)
+    split_iterator = cross_validator.split_dataset(dataset)
+
+    for (train_set, test_set) in split_iterator:
+        ntrain = len(train_set.vis_indexed)
+        ntest = len(test_set.vis_indexed)
+    
+    ratio = ntrain / (ntrain + ntest)
+
+    np.testing.assert_allclose(ratio, 0.8, atol=0.05)
+
 
 def test_crossvalclass_split_randomcell(coords, imager, dataset, generic_parameters):
     # using the CrossValidate class, split a dataset into train/test subsets 

--- a/test/crossval_test.py
+++ b/test/crossval_test.py
@@ -21,7 +21,11 @@ def test_crossvalclass_split_dartboard(coords, imager, dataset, generic_paramete
     cross_validator = CrossValidate(coords, imager, **crossval_pars)
     cross_validator.split_dataset(dataset)
 
+
 def test_crossvalclass_split_dartboard_1kfold(coords, imager, dataset, generic_parameters):
+    # using the CrossValidate class, split a dataset into train/test subsets 
+    # using 'dartboard' splitter with only 1 k-fold; check that the train set
+    # has ~80% of the model visibilities
 
     crossval_pars = generic_parameters["crossval_pars"]
     crossval_pars["split_method"] = "dartboard"


### PR DESCRIPTION
`DartboardSplitGridded` doesn't currently handle the case for 1 k-fold, only 2+. `DartboardSplitGridded` isn't needed to train on a full dataset obviously, but for a standard train/test procedure, PR adds default behavior in `DartboardSplitGridded` of splitting dataset into (roughly) 80/20 train/test when k-fold == 1. The train set still keeps the smallest dartboard cells, as is does for 2+ k-folds.