### PR TITLE
Manually linewrap long docstrings.

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Install doc dependencies
         run: |
-          pip install .[docs]
+          pip install .[dev]
       - name: Install Pandoc dependency
         run: |
           sudo apt-get install pandoc

--- a/.github/workflows/gh_docs.yml
+++ b/.github/workflows/gh_docs.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.8'
       - name: Install doc deps
         run: |
-          pip install .'[docs]'
+          pip install .'[dev]'
       - name: Install Pandoc dependency
         run: |
           sudo apt-get install pandoc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-toml
       - id: check-added-large-files
-        args: ["--maxkb=5000"]
+        args: ["--maxkb=2000"]
       - id: detect-private-key
       - id: name-tests-test
   - repo: https://github.com/psf/black

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,8 @@
 
 ## v0.2.1
 
-- Fully leaned into the `pyproject.toml` setup to modernize build via [hatch](https://github.com/pypa/hatch). This centralizes the project dependencies and derives package versioning directly from git tags. Intermediate packages built from commits after the latest tag (e.g., `0.2.0`) will have an extra long string, e.g., `0.2.1.dev178+g16cfc3e.d20231223` where the version is a guess at the next version and the hash gives reference to the commit. This means that developers bump versions entirely by tagging a new version with git (or more likely by drafting a new release on the [GitHub release page](https://github.com/MPoL-dev/MPoL/releases)). 
+- Manually line wrapped many docstrings to conform to 88 characters per line or less. Ian thought `black` would do this by default, but actually that [doesn't seem to be the case](https://github.com/psf/black/issues/2865).
+- Fully leaned into the `pyproject.toml` setup to modernize build via [hatch](https://github.com/pypa/hatch). This centralizes the project dependencies and derives package versioning directly from git tags. Intermediate packages built from commits after the latest tag (e.g., `0.2.0`) will have an extra long string, e.g., `0.2.1.dev178+g16cfc3e.d20231223` where the version is a guess at the next version and the hash gives reference to the commit. This means that developers bump versions entirely by tagging a new version with git (or more likely by drafting a new release on the [GitHub release page](https://github.com/MPoL-dev/MPoL/releases)).
 - Removed `setup.py`.
 - TOML does not support adding keyed entries, so creating layered build environments of default, `docs`, `test`, and `dev` as we used to with `setup.py` is laborious and repetitive with `pyproject.toml`. We have simplified the list to be default (key dependencies), `test` (minimal necessary for test-suite), and `dev` (covering everything needed to build the docs and actively develop the package).
 - Removed custom `spheroidal_gridding` routines, tests, and the `UVDataset` object that used them. These have been superseded by the TorchKbNuFFT package. For reference, the old routines (including the tricky `corrfun` math) is preserved in a Gist [here](https://gist.github.com/iancze/f3d2769005a9e2c6731ee6977f166a83).
@@ -19,7 +20,7 @@
 - Reorganized some of the docs API
 - Expanded discussion and demonstration in `optimzation.md` tutorial
 - Localized harcoded Zenodo record reference to single instance, and created new external Zenodo record from which to draw
-- Added [Parametric inference with Pyro tutorial](large-tutorials/pyro.md) 
+- Added [Parametric inference with Pyro tutorial](large-tutorials/pyro.md)
 - Updated some discussion and notation in `rml_intro.md` tutorial
 - Added `mypy` static type checks
 - Added `frank` as a 'test' and 'analysis' extras dependency
@@ -30,7 +31,7 @@
 - Moved and rescoped {class}`~mpol.datasets.KFoldCrossValidatorGridded` to {class}`~mpol.crossval.DartboardSplitGridded` with some syntax changes
 - Altered {class}`~mpol.datasets.GriddedDataset` to subclass from `torch.nn.Module`, altered its args, added PyTorch buffers to it, added {func}`mpol.datasets.GriddedDataset.forward` to it
 - Added class method `from_image_properties` to various classes including {class}`~mpol.images.BaseCube` and {class}`~mpol.images.ImageCube`
-- Altered {class}`~mpol.datasets.UVDataset` to subclass from `torch.utils.data.Dataset`, altered its initialization signature, added new properties 
+- Altered {class}`~mpol.datasets.UVDataset` to subclass from `torch.utils.data.Dataset`, altered its initialization signature, added new properties
 - Altered {class}`~mpol.fourier.FourierCube` args and initialization signature, added PyTorch buffers to it
 - Added {func}`~mpol.fourier.get_vis_residuals`
 - Added new program `mpol.geometry` with new {func}`~mpol.geometry.flat_to_observer` and {func}`~mpol.geometry.observer_to_flat`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,6 @@ source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/mpol/mpol_version.py"
+
+[tool.black]
+line-length = 88

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -204,16 +204,12 @@ class GridCoords:
 
         if np.max(np.abs(uu)) > self.max_grid:
             raise CellSizeError(
-                f"Dataset contains uu spatial frequency measurements larger than those 
-                in the proposed model image. Decrease cell_size 
-                below {max_cell_size} arcsec."
+                f"Dataset contains uu spatial frequency measurements larger than those in the proposed model image. Decrease cell_size below {max_cell_size} arcsec."
             )
 
         if np.max(np.abs(vv)) > self.max_grid:
             raise CellSizeError(
-                f"Dataset contains vv spatial frequency measurements larger than those 
-                in the proposed model image. Decrease cell_size below {max_cell_size} 
-                arcsec."
+                f"Dataset contains vv spatial frequency measurements larger than those in the proposed model image. Decrease cell_size below {max_cell_size} arcsec."
             )
 
     def __eq__(self, other: Any) -> bool:

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -14,40 +14,67 @@ from .utils import get_max_spatial_freq, get_maximum_cell_size
 
 class GridCoords:
     r"""
-    The GridCoords object uses desired image dimensions (via the ``cell_size`` and ``npix`` arguments) to define a corresponding Fourier plane grid.
+    The GridCoords object uses desired image dimensions (via the ``cell_size`` and 
+    ``npix`` arguments) to define a corresponding Fourier plane grid.
 
     Args:
         cell_size (float): width of a single square pixel in [arcsec]
         npix (int): number of pixels in the width of the image
 
-    The Fourier grid is defined over the domain :math:`[-u,+u]`, :math:`[-v,+v]`, even though for real images, technically we could use an RFFT grid from :math:`[0,+u]` to :math:`[-v,+v]`. The reason we opt for a full FFT grid in this instance is implementation simplicity.
+    The Fourier grid is defined over the domain :math:`[-u,+u]`, :math:`[-v,+v]`, even 
+    though for real images, technically we could use an RFFT grid from :math:`[0,+u]` to
+    :math:`[-v,+v]`. The reason we opt for a full FFT grid in this instance is 
+    implementation simplicity.
 
-    Images (and their corresponding Fourier transform quantities) are represented as two-dimensional arrays packed as ``[y, x]`` and ``[v, u]``.  This means that an image with dimensions ``(npix, npix)`` will also have a corresponding FFT Fourier grid with shape ``(npix, npix)``. The native :class:`~mpol.gridding.GridCoords` representation assumes the Fourier grid (and thus image) are laid out as one might normally expect an image (i.e., no ``np.fft.fftshift`` has been applied).
+    Images (and their corresponding Fourier transform quantities) are represented as 
+    two-dimensional arrays packed as ``[y, x]`` and ``[v, u]``.  This means that an 
+    image with dimensions ``(npix, npix)`` will also have a corresponding FFT Fourier 
+    grid with shape ``(npix, npix)``. The native :class:`~mpol.gridding.GridCoords` 
+    representation assumes the Fourier grid (and thus image) are laid out as one might 
+    normally expect an image (i.e., no ``np.fft.fftshift`` has been applied).
 
     After the object is initialized, instance variables can be accessed, for example
 
     >>> myCoords = GridCoords(cell_size=0.005, 512)
     >>> myCoords.img_ext
 
-    :ivar dl: image-plane cell spacing in RA direction (assumed to be positive) [radians]
+    :ivar dl: image-plane cell spacing in RA direction (assumed to be positive) 
+        [radians]
     :ivar dm: image-plane cell spacing in DEC direction [radians]
-    :ivar img_ext: The length-4 list of (left, right, bottom, top) expected by routines like ``matplotlib.pyplot.imshow`` in the ``extent`` parameter assuming ``origin='lower'``. Units of [arcsec]
-    :ivar packed_x_centers_2D: 2D array of l increasing, with fftshifted applied [arcseconds]. Useful for directly evaluating some function to create a packed cube.
-    :ivar packed_y_centers_2D: 2D array of m increasing, with fftshifted applied [arcseconds]. Useful for directly evaluating some function to create a packed cube.
-    :ivar sky_x_centers_2D: 2D array of l arranged for evaluating a sky image [arcseconds]. l coordinate increases to the left (as on sky).
-    :ivar sky_y_centers_2D: 2D array of m arranged for evaluating a sky image [arcseconds]. 
-    :ivar du: Fourier-plane cell spacing in East-West direction [:math:`\mathrm{k}\lambda`]
-    :ivar dv: Fourier-plane cell spacing in North-South direction [:math:`\mathrm{k}\lambda`]
-    :ivar u_centers: 1D array of cell centers in East-West direction [:math:`\mathrm{k}\lambda`].
-    :ivar v_centers: 1D array of cell centers in North-West direction [:math:`\mathrm{k}\lambda`].
-    :ivar u_edges: 1D array of cell edges in East-West direction [:math:`\mathrm{k}\lambda`].
-    :ivar v_edges: 1D array of cell edges in North-South direction [:math:`\mathrm{k}\lambda`].
+    :ivar img_ext: The length-4 list of (left, right, bottom, top) expected by routines 
+        like ``matplotlib.pyplot.imshow`` in the ``extent`` parameter assuming 
+        ``origin='lower'``. Units of [arcsec]
+    :ivar packed_x_centers_2D: 2D array of l increasing, with fftshifted applied 
+        [arcseconds]. Useful for directly evaluating some function to create a 
+        packed cube.
+    :ivar packed_y_centers_2D: 2D array of m increasing, with fftshifted applied 
+        [arcseconds]. Useful for directly evaluating some function to create a 
+        packed cube.
+    :ivar sky_x_centers_2D: 2D array of l arranged for evaluating a sky image 
+        [arcseconds]. l coordinate increases to the left (as on sky).
+    :ivar sky_y_centers_2D: 2D array of m arranged for evaluating a sky image 
+        [arcseconds]. 
+    :ivar du: Fourier-plane cell spacing in East-West direction 
+        [:math:`\mathrm{k}\lambda`]
+    :ivar dv: Fourier-plane cell spacing in North-South direction 
+        [:math:`\mathrm{k}\lambda`]
+    :ivar u_centers: 1D array of cell centers in East-West direction 
+        [:math:`\mathrm{k}\lambda`].
+    :ivar v_centers: 1D array of cell centers in North-West direction 
+        [:math:`\mathrm{k}\lambda`].
+    :ivar u_edges: 1D array of cell edges in East-West direction 
+        [:math:`\mathrm{k}\lambda`].
+    :ivar v_edges: 1D array of cell edges in North-South direction 
+        [:math:`\mathrm{k}\lambda`].
     :ivar u_bin_min: minimum u edge [:math:`\mathrm{k}\lambda`]
     :ivar u_bin_max: maximum u edge [:math:`\mathrm{k}\lambda`]
     :ivar v_bin_min: minimum v edge [:math:`\mathrm{k}\lambda`]
     :ivar v_bin_max: maximum v edge [:math:`\mathrm{k}\lambda`]
-    :ivar max_grid: maximum spatial frequency enclosed by Fourier grid [:math:`\mathrm{k}\lambda`]
-    :ivar vis_ext: length-4 list of (left, right, bottom, top) expected by routines like ``matplotlib.pyplot.imshow`` in the ``extent`` parameter assuming ``origin='lower'``. Units of [:math:`\mathrm{k}\lambda`]
+    :ivar max_grid: maximum spatial frequency enclosed by Fourier grid 
+        [:math:`\mathrm{k}\lambda`]
+    :ivar vis_ext: length-4 list of (left, right, bottom, top) expected by routines 
+        like ``matplotlib.pyplot.imshow`` in the ``extent`` parameter assuming 
+        ``origin='lower'``. Units of [:math:`\mathrm{k}\lambda`]
     """
 
     def __init__(self, cell_size: float, npix: int) -> None:
@@ -154,14 +181,19 @@ class GridCoords:
 
     def check_data_fit(self, uu: npt.ArrayLike, vv: npt.ArrayLike) -> None:
         r"""
-        Test whether loose data visibilities fit within the Fourier grid defined by cell_size and npix.
+        Test whether loose data visibilities fit within the Fourier grid defined by 
+        cell_size and npix.
 
         Args:
-            uu (np.array): array of u spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-            vv (np.array): array of v spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
+            uu (np.array): array of u spatial frequency coordinates. 
+                Units of [:math:`\mathrm{k}\lambda`]
+            vv (np.array): array of v spatial frequency coordinates. 
+                Units of [:math:`\mathrm{k}\lambda`]
 
         Returns:
-            ``True`` if all visibilities fit within the Fourier grid defined by ``[u_bin_min, u_bin_max, v_bin_min, v_bin_max]``. Otherwise an ``AssertionError`` is raised on the first violated boundary.
+            ``True`` if all visibilities fit within the Fourier grid defined by 
+            ``[u_bin_min, u_bin_max, v_bin_min, v_bin_max]``. Otherwise an 
+            ``AssertionError`` is raised on the first violated boundary.
         """
 
         # max freq in dataset
@@ -172,12 +204,16 @@ class GridCoords:
 
         if np.max(np.abs(uu)) > self.max_grid:
             raise CellSizeError(
-                f"Dataset contains uu spatial frequency measurements larger than those in the proposed model image. Decrease cell_size below {max_cell_size} arcsec."
+                f"Dataset contains uu spatial frequency measurements larger than those 
+                in the proposed model image. Decrease cell_size 
+                below {max_cell_size} arcsec."
             )
 
         if np.max(np.abs(vv)) > self.max_grid:
             raise CellSizeError(
-                f"Dataset contains vv spatial frequency measurements larger than those in the proposed model image. Decrease cell_size below {max_cell_size} arcsec."
+                f"Dataset contains vv spatial frequency measurements larger than those 
+                in the proposed model image. Decrease cell_size below {max_cell_size} 
+                arcsec."
             )
 
     def __eq__(self, other: Any) -> bool:
@@ -185,6 +221,6 @@ class GridCoords:
             # don't attempt to compare against different types
             return NotImplemented
 
-        # GridCoords objects are considered equal if they have the same cell_size and npix, since
-        # all other attributes are derived from these two core properties.
+        # GridCoords objects are considered equal if they have the same cell_size and 
+        # npix, since all other attributes are derived from these two core properties.
         return self.cell_size == other.cell_size and self.npix == other.npix

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -444,9 +444,9 @@ class RandomCellSplitGridded:
 class DartboardSplitGridded:
     r"""
     Split a GriddedDataset into :math:`k` non-overlapping chunks, internally partitioned
-      by a Dartboard. Inherit the properties of the GriddedDataset. This object creates
-      an iterator providing a (train, test) pair of
-      :class:`~mpol.datasets.GriddedDataset` for each k-fold.
+    by a Dartboard. Inherit the properties of the GriddedDataset. This object creates
+    an iterator providing a (train, test) pair of
+    :class:`~mpol.datasets.GriddedDataset` for each k-fold.
 
     Args:
         griddedDataset (:class:`~mpol.datasets.GriddedDataset`): instance of the
@@ -541,21 +541,21 @@ class DartboardSplitGridded:
         Alternative method to initialize a DartboardSplitGridded object from
         Dartboard parameters.
 
-         Args:
-             griddedDataset (:class:`~mpol.datasets.GriddedDataset`): instance of the
+        Args:
+            griddedDataset (:class:`~mpol.datasets.GriddedDataset`): instance of the
                 gridded dataset
-             k (int): the number of subpartitions of the dataset
-             q_edges (1D numpy array): an array of radial bin edges to set the
+            k (int): the number of subpartitions of the dataset
+                q_edges (1D numpy array): an array of radial bin edges to set the
                 dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults
                 to 12 log-linearly radial bins stretching from 0 to the
                 :math:`q_\mathrm{max}` represented by ``coords``.
-             phi_edges (1D numpy array): an array of azimuthal bin edges to set the
+            phi_edges (1D numpy array): an array of azimuthal bin edges to set the
                 dartboard cells in [radians]. If ``None``, defaults to 8 equal-spaced
                 azimuthal bins stretched from :math:`0` to :math:`\pi`.
-             seed (int): (optional) numpy random seed to use for the permutation,
+                seed (int): (optional) numpy random seed to use for the permutation,
                 for reproducibility
-             verbose (bool): whether to print notification messages
-        """
+            verbose (bool): whether to print notification messages
+    """
         dartboard = Dartboard(gridded_dataset.coords, q_edges, phi_edges)
         return cls(gridded_dataset, k, dartboard, seed, verbose)
 

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -20,19 +20,27 @@ from .utils import loglinspace
 class GriddedDataset(torch.nn.Module):
     r"""
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        vis_gridded (torch complex): the gridded visibility data stored in a "packed" format (pre-shifted for fft)
-        weight_gridded (torch double): the weights corresponding to the gridded visibility data, also in a packed format
-        mask (torch boolean): a boolean mask to index the non-zero locations of ``vis_gridded`` and ``weight_gridded`` in their packed format.
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        vis_gridded (torch complex): the gridded visibility data stored in a "packed" 
+            format (pre-shifted for fft)
+        weight_gridded (torch double): the weights corresponding to the gridded 
+            visibility data, also in a packed format
+        mask (torch boolean): a boolean mask to index the non-zero locations of 
+            ``vis_gridded`` and ``weight_gridded`` in their packed format.
         nchan (int): the number of channels in the image (default = 1).
-        device (torch.device) : the desired device of the dataset. If ``None``, defaults to current device.
+        device (torch.device) : the desired device of the dataset. If ``None``, 
+            defaults to current device.
 
-    After initialization, the GriddedDataset provides the non-zero cells of the gridded visibilities and weights as a 1D vector via the following instance variables. This means that any individual channel information has been collapsed.
+    After initialization, the GriddedDataset provides the non-zero cells of the 
+    gridded visibilities and weights as a 1D vector via the following instance 
+    variables. This means that any individual channel information has been collapsed.
 
     :ivar vis_indexed: 1D complex tensor of visibility data
     :ivar weight_indexed: 1D tensor of weight values
 
-    If you index the output of the Fourier layer in the same manner using ``self.mask``, then the model and data visibilities can be directly compared using a loss function.
+    If you index the output of the Fourier layer in the same manner using ``self.mask``,
+    then the model and data visibilities can be directly compared using a loss function.
     """
 
     def __init__(
@@ -77,14 +85,18 @@ class GriddedDataset(torch.nn.Module):
         nchan: int = 1,
         device: torch.device | str | None = None,
     ):
-        """Alternative method to instantiate a GriddedDataset object from cell_size and npix.
+        """Alternative method to instantiate a GriddedDataset object from cell_size 
+        and npix.
 
         Args:
             cell_size (float): the width of a pixel [arcseconds]
             npix (int): the number of pixels per image side
-            vis_gridded (torch complex): the gridded visibility data stored in a "packed" format (pre-shifted for fft)
-            weight_gridded (torch double): the weights corresponding to the gridded visibility data, also in a packed format
-            mask (torch boolean): a boolean mask to index the non-zero locations of ``vis_gridded`` and ``weight_gridded`` in their packed format.
+            vis_gridded (torch complex): the gridded visibility data stored in a 
+                "packed" format (pre-shifted for fft)
+            weight_gridded (torch double): the weights corresponding to the gridded 
+                visibility data, also in a packed format
+            mask (torch boolean): a boolean mask to index the non-zero locations of 
+                ``vis_gridded`` and ``weight_gridded`` in their packed format.
             nchan (int): the number of channels in the image (default = 1).
         """
         return cls(
@@ -100,16 +112,19 @@ class GriddedDataset(torch.nn.Module):
         mask: ArrayLike,
     ) -> None:
         r"""
-        Apply an additional mask to the data. Only works as a data limiting operation (i.e., ``mask`` is more restrictive than the mask already attached to the dataset).
+        Apply an additional mask to the data. Only works as a data limiting operation 
+        (i.e., ``mask`` is more restrictive than the mask already attached 
+        to the dataset).
 
         Args:
-            mask (2D numpy or PyTorch tensor): boolean mask (in packed format) to apply to dataset. Assumes input will be broadcast across all channels.
+            mask (2D numpy or PyTorch tensor): boolean mask (in packed format) to 
+            apply to dataset. Assumes input will be broadcast across all channels.
         """
 
         new_2D_mask = torch.Tensor(mask).detach()
         new_3D_mask = torch.broadcast_to(new_2D_mask, self.mask.size())
 
-        # update mask via an AND operation, meaning we will only keep visibilities that are
+        # update mask via an AND operation, we will only keep visibilities that are
         # 1) part of the original dataset
         # 2) valid within the new mask
         self.mask = torch.logical_and(self.mask, new_3D_mask)
@@ -128,10 +143,13 @@ class GriddedDataset(torch.nn.Module):
     def forward(self, modelVisibilityCube):
         """
         Args:
-            modelVisibilityCube (complex torch.tensor): with shape ``(nchan, npix, npix)`` to be indexed. In "pre-packed" format, as in output from :meth:`mpol.fourier.FourierCube.forward()`
+            modelVisibilityCube (complex torch.tensor): with shape 
+            ``(nchan, npix, npix)`` to be indexed. In "pre-packed" format, as in 
+            output from :meth:`mpol.fourier.FourierCube.forward()`
 
         Returns:
-            torch complex tensor:  1d torch tensor of indexed model samples collapsed across cube dimensions.
+            torch complex tensor:  1d torch tensor of indexed model samples collapsed 
+            across cube dimensions.
         """
 
         assert (
@@ -162,12 +180,22 @@ class GriddedDataset(torch.nn.Module):
 
 class Dartboard:
     r"""
-    A polar coordinate grid relative to a :class:`~mpol.coordinates.GridCoords` object, reminiscent of a dartboard layout. The main utility of this object is to support splitting a dataset along radial and azimuthal bins for k-fold cross validation.
+    A polar coordinate grid relative to a :class:`~mpol.coordinates.GridCoords` object, 
+    reminiscent of a dartboard layout. The main utility of this object is to support 
+    splitting a dataset along radial and azimuthal bins for k-fold cross validation.
 
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        q_edges (1D numpy array): an array of radial bin edges to set the dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults to 12 log-linearly radial bins stretching from 0 to the :math:`q_\mathrm{max}` represented by ``coords``.
-        phi_edges (1D numpy array): an array of azimuthal bin edges to set the dartboard cells in [radians], over the domain :math:`[0, \pi]`, which is also implicitly mapped to the domain :math:`[-\pi, \pi]` to preserve the Hermitian nature of the visibilities. If ``None``, defaults to 8 equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        q_edges (1D numpy array): an array of radial bin edges to set the dartboard 
+            cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults to 12 
+            log-linearly radial bins stretching from 0 to the :math:`q_\mathrm{max}` 
+            represented by ``coords``.
+        phi_edges (1D numpy array): an array of azimuthal bin edges to set the 
+            dartboard cells in [radians], over the domain :math:`[0, \pi]`, which is 
+            also implicitly mapped to the domain :math:`[-\pi, \pi]` to preserve the 
+            Hermitian nature of the visibilities. If ``None``, defaults to 
+            8 equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
     """
 
     def __init__(
@@ -186,13 +214,15 @@ class Dartboard:
             raise ValueError("Elements of phi_edges must be between 0 and pi.")
 
         if q_edges is None:
-            # set q edges approximately following inspriation from Petry et al. scheme:
+            # set q edges approximately following inspiration from Petry et al. scheme:
             # https://ui.adsabs.harvard.edu/abs/2020SPIE11449E..1DP/abstract
             # first two bins set to 7m width
-            # after third bin, bin width increases linearly until it is 700m at 16km baseline.
+            # after third bin, bin width increases linearly until it is 
+            # 700m at 16km baseline.
             # From 16m to 16km, bin width goes from 7m to 700m.
             # ---
-            # We aren't doing quite the same thing, just logspacing with a few linear cells at the start.
+            # We aren't doing *quite* the same thing, 
+            # just logspacing with a few linear cells at the start.
             q_edges = loglinspace(0, self.q_max, N_log=8, M_linear=5)
 
         self.q_edges = q_edges
@@ -224,8 +254,15 @@ class Dartboard:
         Args:
             cell_size (float): the width of a pixel [arcseconds]
             npix (int): the number of pixels per image side
-            q_edges (1D numpy array): an array of radial bin edges to set the dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults to 12 log-linearly radial bins stretching from 0 to the :math:`q_\mathrm{max}` represented by ``coords``.
-            phi_edges (1D numpy array): an array of azimuthal bin edges to set the dartboard cells in [radians], over the domain :math:`[0, \pi]`, which is also implicitly mapped to the domain :math:`[-\pi, \pi]` to preserve the Hermitian nature of the visibilities. If ``None``, defaults to 8 equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
+            q_edges (1D numpy array): an array of radial bin edges to set the 
+                dartboard cells in :math:`[\mathrm{k}\lambda]`. If ``None``, defaults 
+                to 12 log-linearly radial bins stretching from 0 to the 
+                :math:`q_\mathrm{max}` represented by ``coords``.
+            phi_edges (1D numpy array): an array of azimuthal bin edges to set the 
+                dartboard cells in [radians], over the domain :math:`[0, \pi]`, which 
+                is also implicitly mapped to the domain :math:`[-\pi, \pi]` to preserve 
+                the Hermitian nature of the visibilities. If ``None``, defaults to 8 
+                equal-spaced azimuthal bins stretched from :math:`0` to :math:`\pi`.
         """
         coords = GridCoords(cell_size, npix)
         return cls(coords, q_edges, phi_edges)
@@ -234,15 +271,18 @@ class Dartboard:
         self, qs: NDArray[floating[Any]], phis: NDArray[floating[Any]]
     ) -> NDArray[floating[Any]]:
         r"""
-        Calculate a histogram in polar coordinates, using the bin edges defined by ``q_edges`` and ``phi_edges`` during initialization.
+        Calculate a histogram in polar coordinates, using the bin edges defined by 
+        ``q_edges`` and ``phi_edges`` during initialization.
         Data coordinates should include the points for the Hermitian visibilities.
 
         Args:
             qs: 1d array of q values :math:`[\mathrm{k}\lambda]`
-            phis: 1d array of datapoint azimuth values [radians] (must be the same length as qs)
+            phis: 1d array of datapoint azimuth values [radians] (must be the same 
+            length as qs)
 
         Returns:
-            2d integer numpy array of cell counts, i.e., how many datapoints fell into each dartboard cell.
+            2d integer numpy array of cell counts, i.e., how many datapoints fell into 
+            each dartboard cell.
         """
 
         histogram: NDArray
@@ -257,12 +297,14 @@ class Dartboard:
         self, qs: NDArray[floating[Any]], phis: NDArray[floating[Any]]
     ) -> NDArray[integer[Any]]:
         r"""
-        Return a list of the cell indices that contain data points, using the bin edges defined by ``q_edges`` and ``phi_edges`` during initialization.
+        Return a list of the cell indices that contain data points, using the bin edges 
+        defined by ``q_edges`` and ``phi_edges`` during initialization.
         Data coordinates should include the points for the Hermitian visibilities.
 
         Args:
             qs: 1d array of q values :math:`[\mathrm{k}\lambda]`
-            phis: 1d array of datapoint azimuth values [radians] (must be the same length as qs)
+            phis: 1d array of datapoint azimuth values [radians] (must be the same 
+            length as qs)
 
         Returns:
             list of cell indices where cell contains at least one datapoint.
@@ -279,10 +321,13 @@ class Dartboard:
         self, cell_index_list: NDArray[integer[Any]]
     ) -> NDArray[np.bool_]:
         r"""
-        Create a boolean mask of size ``(npix, npix)`` (in packed format) corresponding to the ``vis_gridded`` and ``weight_gridded`` quantities of the :class:`~mpol.datasets.GriddedDataset` .
+        Create a boolean mask of size ``(npix, npix)`` (in packed format) corresponding 
+        to the ``vis_gridded`` and ``weight_gridded`` quantities of the 
+        :class:`~mpol.datasets.GriddedDataset` .
 
         Args:
-            cell_index_list (list): list or iterable containing [q_cell, phi_cell] index pairs to include in the mask.
+            cell_index_list (list): list or iterable containing [q_cell, phi_cell] index
+            pairs to include in the mask.
 
         Returns: (numpy array) 2D boolean mask in packed format.
         """

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -29,7 +29,7 @@ class GriddedDataset(torch.nn.Module):
         mask (torch boolean): a boolean mask to index the non-zero locations of 
             ``vis_gridded`` and ``weight_gridded`` in their packed format.
         nchan (int): the number of channels in the image (default = 1).
-        device (torch.device) : the desired device of the dataset. If ``None``, 
+        device (torch.device): the desired device of the dataset. If ``None``, 
             defaults to current device.
 
     After initialization, the GriddedDataset provides the non-zero cells of the 
@@ -38,7 +38,7 @@ class GriddedDataset(torch.nn.Module):
 
     :ivar vis_indexed: 1D complex tensor of visibility data
     :ivar weight_indexed: 1D tensor of weight values
-
+    
     If you index the output of the Fourier layer in the same manner using ``self.mask``,
     then the model and data visibilities can be directly compared using a loss function.
     """
@@ -118,7 +118,7 @@ class GriddedDataset(torch.nn.Module):
 
         Args:
             mask (2D numpy or PyTorch tensor): boolean mask (in packed format) to 
-            apply to dataset. Assumes input will be broadcast across all channels.
+                apply to dataset. Assumes input will be broadcast across all channels.
         """
 
         new_2D_mask = torch.Tensor(mask).detach()
@@ -144,12 +144,12 @@ class GriddedDataset(torch.nn.Module):
         """
         Args:
             modelVisibilityCube (complex torch.tensor): with shape 
-            ``(nchan, npix, npix)`` to be indexed. In "pre-packed" format, as in 
-            output from :meth:`mpol.fourier.FourierCube.forward()`
+                ``(nchan, npix, npix)`` to be indexed. In "pre-packed" format, as in 
+                output from :meth:`mpol.fourier.FourierCube.forward()`
 
         Returns:
             torch complex tensor:  1d torch tensor of indexed model samples collapsed 
-            across cube dimensions.
+                across cube dimensions.
         """
 
         assert (
@@ -278,7 +278,7 @@ class Dartboard:
         Args:
             qs: 1d array of q values :math:`[\mathrm{k}\lambda]`
             phis: 1d array of datapoint azimuth values [radians] (must be the same 
-            length as qs)
+                length as qs)
 
         Returns:
             2d integer numpy array of cell counts, i.e., how many datapoints fell into 
@@ -304,7 +304,7 @@ class Dartboard:
         Args:
             qs: 1d array of q values :math:`[\mathrm{k}\lambda]`
             phis: 1d array of datapoint azimuth values [radians] (must be the same 
-            length as qs)
+                length as qs)
 
         Returns:
             list of cell indices where cell contains at least one datapoint.
@@ -327,7 +327,7 @@ class Dartboard:
 
         Args:
             cell_index_list (list): list or iterable containing [q_cell, phi_cell] index
-            pairs to include in the mask.
+                pairs to include in the mask.
 
         Returns: (numpy array) 2D boolean mask in packed format.
         """

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -23,19 +23,19 @@ from .coordinates import GridCoords
 
 class FourierCube(nn.Module):
     r"""
-    This layer performs the FFT of an ImageCube and stores the corresponding dense FFT 
-    output as a cube. If you are using this layer in a forward-modeling RML workflow, 
-    because the FFT of the model is essentially stored as a grid, you will need to make 
-    the loss function calculation using a gridded loss function (e.g., 
-    :func:`mpol.losses.nll_gridded`) and a gridded dataset (e.g., 
+    This layer performs the FFT of an ImageCube and stores the corresponding dense FFT
+    output as a cube. If you are using this layer in a forward-modeling RML workflow,
+    because the FFT of the model is essentially stored as a grid, you will need to make
+    the loss function calculation using a gridded loss function (e.g.,
+    :func:`mpol.losses.nll_gridded`) and a gridded dataset (e.g.,
     :class:`mpol.datasets.GriddedDataset`).
 
     Args:
         coords (GridCoords): an object already instantiated from the GridCoords class.
-        persistent_vis (Boolean): should the visibility cube be stored as part of the 
-        modules `state_dict`? If `True`, the state of the UV grid will be stored. It is 
-        recommended to use `False` for most applications, since the visibility cube will
-          rarely be a direct parameter of the model.
+        persistent_vis (Boolean): should the visibility cube be stored as part of 
+            the module  s `state_dict`? If `True`, the state of the UV grid will be 
+            stored. It is recommended to use `False` for most applications, since the 
+            visibility cube will rarely be a direct parameter of the model.
 
     """
 
@@ -59,15 +59,15 @@ class FourierCube(nn.Module):
         cls, cell_size: float, npix: int, persistent_vis: bool = False
     ) -> FourierCube:
         """
-        Alternative method for instantiating a FourierCube from ``cell_size`` and 
+        Alternative method for instantiating a FourierCube from ``cell_size`` and
         ``npix``
 
         Args:
             cell_size (float): the width of an image-plane pixel [arcseconds]
             npix (int): the number of pixels per image side
-            persistent_vis (Boolean): should the visibility cube be stored as part of 
-                the modules `state_dict`? If `True`, the state of the UV grid will be 
-                stored. It is recommended to use `False` for most applications, since 
+            persistent_vis (Boolean): should the visibility cube be stored as part of
+                the modules `state_dict`? If `True`, the state of the UV grid will be
+                stored. It is recommended to use `False` for most applications, since
                 the visibility cube will rarely be a direct parameter of the model.
 
         Returns:
@@ -81,12 +81,13 @@ class FourierCube(nn.Module):
         Perform the FFT of the image cube on each channel.
 
         Args:
-            cube (torch.double tensor, of shape ``(nchan, npix, npix)``): a prepacked 
-            image cube, for example, from ImageCube.forward()
+            cube (torch.double tensor): a prepacked tensor of shape 
+                ``(nchan, npix, npix)``. For example, an image cube 
+                from ImageCube.forward()
 
         Returns:
-            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the 
-            image cube, in packed format.
+            torch.complex tensor, of shape ``(nchan, npix, npix)``. The FFT of the
+                image cube, in packed format.
         """
 
         # make sure the cube is 3D
@@ -102,12 +103,12 @@ class FourierCube(nn.Module):
     @property
     def ground_vis(self) -> torch.Tensor:
         r"""
-        The visibility cube in ground format cube fftshifted for plotting with 
+        The visibility cube in ground format cube fftshifted for plotting with
         ``imshow``.
 
         Returns:
-            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the 
-            image cube, in sky plane format.
+            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the
+                image cube, in sky plane format.
         """
 
         return utils.packed_cube_to_ground_cube(self.vis)
@@ -115,7 +116,7 @@ class FourierCube(nn.Module):
     @property
     def ground_amp(self) -> torch.Tensor:
         r"""
-        The amplitude of the cube, arranged in unpacked format corresponding to the FFT 
+        The amplitude of the cube, arranged in unpacked format corresponding to the FFT
         of the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
 
         Returns:
@@ -126,7 +127,7 @@ class FourierCube(nn.Module):
     @property
     def ground_phase(self) -> torch.Tensor:
         r"""
-        The phase of the cube, arranged in unpacked format corresponding to the FFT of 
+        The phase of the cube, arranged in unpacked format corresponding to the FFT of
         the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
 
         Returns:
@@ -143,43 +144,43 @@ def safe_baseline_constant_meters(
     uv_cell_frac: float = 0.05,
 ) -> bool:
     r"""
-    This routine determines whether the baselines can safely be assumed to be constant 
+    This routine determines whether the baselines can safely be assumed to be constant
     with channel when they converted from meters to units of kilolambda.
 
     The antenna baselines *are* the same as a function of channel when they are measured
-      in physical distance units, such as meters. However, when these baselines are 
-      converted to spatial frequency units, via
+    in physical distance units, such as meters. However, when these baselines are
+    converted to spatial frequency units, via
 
     .. math::
 
         u = \frac{D}{\lambda},
 
-    it's possible that the :math:`u` and :math:`v` values of each channel are 
-    significantly different if the :math:`\lambda` values of each channel are 
-    significantly different. This routine evaluates whether the maximum change in 
-    :math:`u` or :math:`v` across channels (when represented in kilolambda) is smaller 
+    it's possible that the :math:`u` and :math:`v` values of each channel are
+    significantly different if the :math:`\lambda` values of each channel are
+    significantly different. This routine evaluates whether the maximum change in
+    :math:`u` or :math:`v` across channels (when represented in kilolambda) is smaller
     than some threshold value, calculated as the fraction of a :math:`u,v` cell defined
     by ``coords``.
 
-    If this function returns ``True``, then it would be safe to proceed with 
+    If this function returns ``True``, then it would be safe to proceed with
     parallelization in the :class:`mpol.fourier.NuFFT` layer via the coil dimension.
 
     Args:
-        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) 
+        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West)
             spatial frequency coordinate in units of [m]
-        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) 
+        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South)
             spatial frequency coordinate in units of [m]
-        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, 
+        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies,
             in units of [Hz].
         coords: a :class:`mpol.coordinates.GridCoords` object which represents the image
             and uv-grid dimensions.
-        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or 
-            :math:`v` spatial frequency across channels, measured as a fraction of the 
+        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or
+            :math:`v` spatial frequency across channels, measured as a fraction of the
             :math:`u,v` cell defined by ``coords``.
 
     Returns:
-        boolean: `True` if it is safe to assume that the baselines are constant with 
-        channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
+        boolean: `True` if it is safe to assume that the baselines are constant with
+            channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
     """
 
     # broadcast and convert baselines to kilolambda across channel
@@ -212,34 +213,34 @@ def safe_baseline_constant_kilolambda(
     uv_cell_frac: float = 0.05,
 ) -> bool:
     r"""
-    This routine determines whether the baselines can safely be assumed to be constant 
+    This routine determines whether the baselines can safely be assumed to be constant
     with channel, when the are represented in units of kilolambda.
 
     Compared to :class:`mpol.fourier.safe_baseline_constant_meters`, this function works
-    with multidimensional arrays of ``uu`` and ``vv`` that are shape (nchan, nvis) and 
+    with multidimensional arrays of ``uu`` and ``vv`` that are shape (nchan, nvis) and
     have units of kilolambda.
 
-    If this routine returns True, then it should be safe for the user to either average 
+    If this routine returns True, then it should be safe for the user to either average
     the baselines across channel or simply choose a single, representative channel. This
-    would enable parallelization in the {class}`mpol.fourier.NuFFT` via the coil 
+    would enable parallelization in the {class}`mpol.fourier.NuFFT` via the coil
     dimension.
 
     Args:
-        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) 
+        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West)
             spatial frequency coordinate in units of [m]
-        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) 
+        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South)
             spatial frequency coordinate in units of [m]
-        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, 
+        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies,
             in units of [Hz].
-        coords: a :class:`mpol.coordinates.GridCoords` object which represents the 
+        coords: a :class:`mpol.coordinates.GridCoords` object which represents the
             image and uv-grid dimensions.
-        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or 
-            :math:`v` spatial frequency across channels, measured as a fraction of the 
+        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or
+            :math:`v` spatial frequency across channels, measured as a fraction of the
             :math:`u,v` cell defined by ``coords``.
 
     Returns:
-        boolean: `True` if it is safe to assume that the baselines are constant with 
-        channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
+        boolean: `True` if it is safe to assume that the baselines are constant with
+            channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
 
     """
     # convert uv_cell_frac to a kilolambda threshold
@@ -268,18 +269,18 @@ def safe_baseline_constant_kilolambda(
 # NuFFT
 class NuFFT(nn.Module):
     r"""
-    This layer translates input from an :class:`mpol.images.ImageCube` to loose, 
-    ungridded samples of the Fourier plane, corresponding to the :math:`u,v` locations 
-    provided. This layer is different than a :class:`mpol.Fourier.FourierCube` in that, 
-    rather than producing the dense cube-like output from an FFT routine, it utilizes 
-    the non-uniform FFT or 'NuFFT' to interpolate directly to discrete :math:`u,v` 
-    locations. This is implemented using the KbNufft routines of the `TorchKbNufft 
+    This layer translates input from an :class:`mpol.images.ImageCube` to loose,
+    ungridded samples of the Fourier plane, corresponding to the :math:`u,v` locations
+    provided. This layer is different than a :class:`mpol.Fourier.FourierCube` in that,
+    rather than producing the dense cube-like output from an FFT routine, it utilizes
+    the non-uniform FFT or 'NuFFT' to interpolate directly to discrete :math:`u,v`
+    locations. This is implemented using the KbNufft routines of the `TorchKbNufft
     <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
 
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. 
+        coords (GridCoords): an object already instantiated from the GridCoords class.
             If providing this, cannot provide ``cell_size`` or ``npix``.
-        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`.
             Default = 1.
     """
 
@@ -306,13 +307,13 @@ class NuFFT(nn.Module):
         nchan: int = 1,
     ):
         """
-        Instantiate a :class:`mpol.fourier.NuFFT` object from image properties rather 
+        Instantiate a :class:`mpol.fourier.NuFFT` object from image properties rather
         than a :meth:`mpol.coordinates.GridCoords` instance.
 
         Args:
             cell_size (float): the width of an image-plane pixel [arcseconds]
             npix (int): the number of pixels per image side
-            nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+            nchan (int): the number of channels in the :class:`mpol.images.ImageCube`.
                 Default = 1.
 
         Returns:
@@ -325,7 +326,7 @@ class NuFFT(nn.Module):
         )
 
     def _klambda_to_radpix(self, klambda: torch.Tensor) -> torch.Tensor:
-        """Convert a spatial frequency in units of klambda to 'radians/sky pixel,' 
+        """Convert a spatial frequency in units of klambda to 'radians/sky pixel,'
         using the pixel cell_size provided by ``self.coords.dl``.
 
         Args:
@@ -334,29 +335,29 @@ class NuFFT(nn.Module):
         Returns:
             torch.Tensor: spatial frequency measured in units of radian per sky pixel
 
-        These concepts can be a little confusing because there are two angular measures 
+        These concepts can be a little confusing because there are two angular measures
         at play.
 
-        1. The first is the normal angular sky coordinate, normally measured in 
-        arcseconds for typical sources observed by ALMA or the VLA. Arcseconds, being 
-        an angular coordinate, can equivalently be expressed in units of radians. To 
-        avoid confusion, we will call this angular measurement 'sky radians.' 
-        Alternatively, for a given image grid, this same sky coordinate could be 
+        1. The first is the normal angular sky coordinate, normally measured in
+        arcseconds for typical sources observed by ALMA or the VLA. Arcseconds, being
+        an angular coordinate, can equivalently be expressed in units of radians. To
+        avoid confusion, we will call this angular measurement 'sky radians.'
+        Alternatively, for a given image grid, this same sky coordinate could be
         expressed in units of sky pixels.
-        2. The second is the spatial frequency of some image-plane function, 
-        :math:`I_\nu(l,m)`, which we could quote in units of 'cycles per arcsecond' or 
-        'cycles per sky pixel,' for example. With a radio interferometer, spatial 
-        frequencies are typically quoted in units of the observing wavelength, i.e., 
-        lambda or kilo-lambda. If the field of view of the image is small, thanks to 
-        the small-angle approximation, units of lambda are directly equivalent to 
-        'cycles per sky radian.' The second angular measure comes about when converting 
+        2. The second is the spatial frequency of some image-plane function,
+        :math:`I_\nu(l,m)`, which we could quote in units of 'cycles per arcsecond' or
+        'cycles per sky pixel,' for example. With a radio interferometer, spatial
+        frequencies are typically quoted in units of the observing wavelength, i.e.,
+        lambda or kilo-lambda. If the field of view of the image is small, thanks to
+        the small-angle approximation, units of lambda are directly equivalent to
+        'cycles per sky radian.' The second angular measure comes about when converting
         the spatial frequency from a linear measure of frequency 'cycles per sky radian'
-        to an angular measure of frequency 'radians per sky radian' or 'radians per 
+        to an angular measure of frequency 'radians per sky radian' or 'radians per
         sky pixel.'
 
-        The TorchKbNufft package expects k-trajectory vectors in units of 'radians per 
+        The TorchKbNufft package expects k-trajectory vectors in units of 'radians per
         sky pixel.' This routine helps convert spatial frequencies from their default
-        unit (kilolambda) into 'radians per sky pixel' using the pixel cell_size as 
+        unit (kilolambda) into 'radians per sky pixel' using the pixel cell_size as
         provided by ``self.coords.dl``.
         """
 
@@ -376,26 +377,26 @@ class NuFFT(nn.Module):
 
     def _assemble_ktraj(self, uu: torch.Tensor, vv: torch.Tensor) -> torch.Tensor:
         r"""
-        This routine converts a series of :math:`u, v` coordinates into a k-trajectory 
-        vector for the torchkbnufft routines. The dimensionality of the k-trajectory 
+        This routine converts a series of :math:`u, v` coordinates into a k-trajectory
+        vector for the torchkbnufft routines. The dimensionality of the k-trajectory
         vector will influence how TorchKbNufft will perform the operations.
 
-        * If ``uu`` and ``vv`` have a 1D shape of (``nvis``), then it will be assumed 
-        that the spatial frequencies can be treated as constant with channel. This will 
-        result in a ``k_traj`` vector that has shape (``2, nvis``), such that 
-        parallelization will be across the image cube ``nchan`` dimension using the 
-        'coil' dimension of the TorchKbNufft package.
-        * If the ``uu`` and ``vv`` have a 2D shape of (``nchan, nvis``), then it will 
-        be assumed that the spatial frequencies are different for each channel, and the 
-        spatial frequencies provided for each channel will be used. This will result in 
-        a ``k_traj`` vector that has shape (``nchan, 2, nvis``), such that 
-        parallelization will be across the image cube ``nchan`` dimension using the 
-        'batch' dimension of the TorchKbNufft package.
+        * If ``uu`` and ``vv`` have a 1D shape of (``nvis``), then it will be assumed
+            that the spatial frequencies can be treated as constant with channel. This 
+            will result in a ``k_traj`` vector that has shape (``2, nvis``), such that
+            parallelization will be across the image cube ``nchan`` dimension using the
+            'coil' dimension of the TorchKbNufft package.
+        * If the ``uu`` and ``vv`` have a 2D shape of (``nchan, nvis``), then it will
+            be assumed that the spatial frequencies are different for each channel, and 
+            the spatial frequencies provided for each channel will be used. This will 
+            result in a ``k_traj`` vector that has shape (``nchan, 2, nvis``), such that
+            parallelization will be across the image cube ``nchan`` dimension using the
+            'batch' dimension of the TorchKbNufft package.
 
         Args:
-            uu (1D or 2D torch.Tensor array): u (East-West) spatial frequency 
+            uu (1D or 2D torch.Tensor array): u (East-West) spatial frequency
                 coordinate [klambda]
-            vv (1D or 2D torch.Tensor array): v (North-South) spatial frequency 
+            vv (1D or 2D torch.Tensor array): v (North-South) spatial frequency
                 coordinate [klambda]
 
         Returns:
@@ -413,7 +414,7 @@ class NuFFT(nn.Module):
         if same_uv:
             # k-trajectory needs to be packed the way the image is packed (y,x), so
             # the trajectory needs to be packed (v, u)
-            # if TorchKbNufft receives a k-traj tensor of shape (2, nvis), 
+            # if TorchKbNufft receives a k-traj tensor of shape (2, nvis),
             # it will parallelize across the coil dimension, assuming
             # that the k-traj is the same for all coils/channels.
             # interim convert to numpy array because of torch warning about speed
@@ -428,19 +429,17 @@ class NuFFT(nn.Module):
         # then, concatenate the tensors along the axis=1 dimension.
         if uu_radpix.shape[0] != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of uu ({uu_radpix.shape[0]}) is more than one but different than
-                that used to initialize the NuFFT layer ({self.nchan})"
+                f"nchan of uu ({uu_radpix.shape[0]}) is more than one but different than that used to initialize the NuFFT layer ({self.nchan})"
             )
 
         if vv_radpix.shape[0] != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of vv ({vv_radpix.shape[0]}) is more than one but different than
-                that used to initialize the NuFFT layer ({self.nchan})"
+                f"nchan of vv ({vv_radpix.shape[0]}) is more than one but different than that used to initialize the NuFFT layer ({self.nchan})"
             )
 
         uu_radpix_aug = torch.unsqueeze(torch.tensor(uu_radpix), 1)
         vv_radpix_aug = torch.unsqueeze(torch.tensor(vv_radpix), 1)
-        # if TorchKbNufft receives a k-traj tensor of shape (nbatch, 2, nvis), it will 
+        # if TorchKbNufft receives a k-traj tensor of shape (nbatch, 2, nvis), it will
         # parallelize across the batch dimension
         k_traj = torch.cat([vv_radpix_aug, uu_radpix_aug], dim=1)
 
@@ -455,84 +454,84 @@ class NuFFT(nn.Module):
     ) -> torch.Tensor:
         r"""
         Perform the FFT of the image cube for each channel and interpolate to the ``uu``
-        and ``vv`` points. This call should automatically take the best 
-        parallelization option as indicated by the shape of the ``uu`` and ``vv`` 
-        points. In general, you probably do not want to provide baselines that include 
+        and ``vv`` points. This call should automatically take the best
+        parallelization option as indicated by the shape of the ``uu`` and ``vv``
+        points. In general, you probably do not want to provide baselines that include
         Hermitian pairs.
 
         Args:
-            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube 
-                should be a "prepacked" image cube, for example, 
+            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube
+                should be a "prepacked" image cube, for example,
                 from :meth:`mpol.images.ImageCube.forward`
-            uu (array-like): array of the u (East-West) spatial frequency coordinate 
+            uu (array-like): array of the u (East-West) spatial frequency coordinate
                 [klambda].
-            vv (array-like): array of the v (North-South) spatial frequency coordinate 
+            vv (array-like): array of the v (North-South) spatial frequency coordinate
                 [klambda] (must be the same shape as uu)
-            sparse_matrices (bool): If False, use the default table-based interpolation 
-                of TorchKbNufft.If True, use TorchKbNuFFT sparse matrices (generally 
-                slower but more accurate).  Note that sparse matrices are incompatible 
+            sparse_matrices (bool): If False, use the default table-based interpolation
+                of TorchKbNufft.If True, use TorchKbNuFFT sparse matrices (generally
+                slower but more accurate).  Note that sparse matrices are incompatible
                 with multi-channel `uu` and `vv` arrays (see below).
 
         Returns:
-            torch.complex tensor: Fourier samples of shape ``(nchan, nvis)``, evaluated 
-            at the ``uu``, ``vv`` points
+            torch.complex tensor: Fourier samples of shape ``(nchan, nvis)``, evaluated
+                at the ``uu``, ``vv`` points
 
-        **Dimensionality**: You should consider the dimensionality of your image and 
-        your visibility samples when using this method. If your image has multiple 
-        channels (``nchan > 1``), there is the possibility that the :math:`u,v` sample 
-        locations corresponding to each channel may be different. In ALMA/VLA 
-        applications, this can arise when continuum observations are taken over 
-        significant bandwidth, since the spatial frequency sampled by any pair of 
+        **Dimensionality**: You should consider the dimensionality of your image and
+        your visibility samples when using this method. If your image has multiple
+        channels (``nchan > 1``), there is the possibility that the :math:`u,v` sample
+        locations corresponding to each channel may be different. In ALMA/VLA
+        applications, this can arise when continuum observations are taken over
+        significant bandwidth, since the spatial frequency sampled by any pair of
         antennas is wavelength-dependent
 
         .. math::
 
             u = \frac{D}{\lambda},
 
-        where :math:`D` is the projected baseline (measured in, say, meters) and 
-        :math:`\lambda` is the observing wavelength. In this application, the 
+        where :math:`D` is the projected baseline (measured in, say, meters) and
+        :math:`\lambda` is the observing wavelength. In this application, the
         image-plane model could be the same for each channel, or it may vary with
         channel (necessary if the spectral slope of the source is significant).
 
-        On the other hand, with spectral line observations it will usually be the case 
-        that the total bandwidth of the observations is small enough such that the 
-        :math:`u,v` sample locations could be considered as the same for each channel. 
-        In spectral line applications, the image-plane model usually varies 
+        On the other hand, with spectral line observations it will usually be the case
+        that the total bandwidth of the observations is small enough such that the
+        :math:`u,v` sample locations could be considered as the same for each channel.
+        In spectral line applications, the image-plane model usually varies
         substantially with each channel.
 
-        This routine will determine whether the spatial frequencies are treated as 
+        This routine will determine whether the spatial frequencies are treated as
         constant based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
 
-        * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that 
-        the spatial frequencies can be treated as constant with channel (and will invoke
-        parallelization across the image cube ``nchan`` dimension using the 'coil' 
-        dimension of the TorchKbNufft package).
-        * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be 
-        assumed that the spatial frequencies are different for each channel, and the 
-        spatial frequencies provided for each channel will be used (and will invoke 
-        parallelization across the image cube ``nchan`` dimension using the 'batch' 
-        dimension of the TorchKbNufft package).
+        * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that
+            the spatial frequencies can be treated as constant with channel (and will 
+            invoke parallelization across the image cube ``nchan`` dimension using the 
+            'coil' dimension of the TorchKbNufft package).
+        * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be
+            assumed that the spatial frequencies are different for each channel, and the
+            spatial frequencies provided for each channel will be used (and will invoke
+            parallelization across the image cube ``nchan`` dimension using the 'batch'
+            dimension of the TorchKbNufft package).
 
-        Note that there is no straightforward, computationally efficient way to proceed 
-        if there are a different number of spatial frequencies for each channel. The 
-        best approach is likely to construct ``uu`` and ``vv`` arrays that have a shape 
-        of (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` 
-        points to have the same length ``nvis``, and you create a boolean mask to keep 
-        track of which points are valid. Then, when this routine returns data points of 
-        shape (``nchan, nvis``), you can use that boolean mask to select only the valid 
+        Note that there is no straightforward, computationally efficient way to proceed
+        if there are a different number of spatial frequencies for each channel. The
+        best approach is likely to construct ``uu`` and ``vv`` arrays that have a shape
+        of (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v`
+        points to have the same length ``nvis``, and you create a boolean mask to keep
+        track of which points are valid. Then, when this routine returns data points of
+        shape (``nchan, nvis``), you can use that boolean mask to select only the valid
         :math:`u,v` points points.
 
-        **Interpolation mode**: You may choose the type of interpolation mode that 
-        KbNufft uses under the hood by changing the boolean value of 
-        ``sparse_matrices``. If ``sparse_matrices=False``, this routine will use the 
-        default table-based interpolation of TorchKbNufft. If ``sparse_matrices=True``, 
-        the routine will calculate sparse matrices (which can be stored for later 
-        operations, as in {class}`~mpol.fourier.NuFFTCached`) and use them for the 
-        interpolation. This approach is likely to be more accurate but also slower. If 
-        Note that as of TorchKbNuFFT version 1.4.0, sparse matrices are not yet 
-        available when parallelizing using the 'batch' dimension --- this will result 
-        in a warning. For most applications, we anticipate the accuracy of the 
-        table-based interpolation to be sufficiently accurate, but this could change 
+        **Interpolation mode**: You may choose the type of interpolation mode that
+        KbNufft uses under the hood by changing the boolean value of
+        ``sparse_matrices``. If ``sparse_matrices=False``, this routine will use the
+        default table-based interpolation of TorchKbNufft. If ``sparse_matrices=True``,
+        the routine will calculate sparse matrices (which can be stored for later
+        operations, as in {class}`~mpol.fourier.NuFFTCached`) and use them for the
+        interpolation. This approach is likely to be more accurate but also slower. If
+        Note that as of TorchKbNuFFT version 1.4.0, sparse matrices are not yet
+        available when parallelizing using the 'batch' dimension --- this will result
+        in a warning. For most applications, we anticipate the accuracy of the
+        table-based interpolation to be sufficiently accurate, but this could change
         depending on your problem.
         """
 
@@ -544,8 +543,7 @@ class NuFFT(nn.Module):
         # setup are the same
         if cube.size(0) != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of ImageCube ({cube.size(0)}) is different than that used to 
-                initialize NuFFT layer ({self.nchan})"
+                f"nchan of ImageCube ({cube.size(0)}) is different than that used to initialize NuFFT layer ({self.nchan})"
             )
 
         # "unpack" the cube, but leave it flipped
@@ -620,75 +618,77 @@ class NuFFT(nn.Module):
 
 class NuFFTCached(NuFFT):
     r"""
-    This layer translates input from an :class:`mpol.images.ImageCube` directly to 
-    loose, ungridded samples of the Fourier plane, directly corresponding to the 
-    :math:`u,v` locations of the data. This layer is different than a 
+    This layer translates input from an :class:`mpol.images.ImageCube` directly to
+    loose, ungridded samples of the Fourier plane, directly corresponding to the
+    :math:`u,v` locations of the data. This layer is different than a
     :class:`mpol.Fourier.FourierCube` in that, rather than producing the dense cube-like
-    output from an FFT routine, it utilizes the non-uniform FFT or 'NuFFT' to 
-    interpolate directly to discrete :math:`u,v` locations that need not correspond to 
-    grid cell centers. This is implemented using the KbNufft routines of the 
+    output from an FFT routine, it utilizes the non-uniform FFT or 'NuFFT' to
+    interpolate directly to discrete :math:`u,v` locations that need not correspond to
+    grid cell centers. This is implemented using the KbNufft routines of the
     `TorchKbNufft <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
 
     **Dimensionality**: One consideration when using this layer is the dimensionality of
-    your image and your visibility samples. If your image has multiple channels 
-    (``nchan > 1``), there is the possibility that the :math:`u,v` sample locations 
-    corresponding to each channel may be different. In ALMA/VLA applications, this can 
-    arise when continuum observations are taken over significant bandwidth, since the 
+    your image and your visibility samples. If your image has multiple channels
+    (``nchan > 1``), there is the possibility that the :math:`u,v` sample locations
+    corresponding to each channel may be different. In ALMA/VLA applications, this can
+    arise when continuum observations are taken over significant bandwidth, since the
     spatial frequency sampled by any pair of antennas is wavelength-dependent
 
     .. math::
 
         u = \frac{D}{\lambda},
 
-    where :math:`D` is the projected baseline (measured in, say, meters) and 
-    :math:`\lambda` is the observing wavelength. In this application, the image-plane 
-    model could be the same for each channel, or it may vary with channel (necessary if 
+    where :math:`D` is the projected baseline (measured in, say, meters) and
+    :math:`\lambda` is the observing wavelength. In this application, the image-plane
+    model could be the same for each channel, or it may vary with channel (necessary if
     the spectral slope of the source is significant).
 
-    On the other hand, with spectral line observations it will usually be the case that 
-    the total bandwidth of the observations is small enough such that the :math:`u,v` 
-    sample locations could be considered as the same for each channel. In spectral line 
+    On the other hand, with spectral line observations it will usually be the case that
+    the total bandwidth of the observations is small enough such that the :math:`u,v`
+    sample locations could be considered as the same for each channel. In spectral line
     applications, the image-plane model usually varies substantially with each channel.
 
-    This layer will determine whether the spatial frequencies are treated as constant 
+    This layer will determine whether the spatial frequencies are treated as constant
     based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
 
-    * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that the 
-    spatial frequencies can be treated as constant with channel (and will invoke 
-    parallelization across the image cube ``nchan`` dimension using the 'coil' dimension
-    of the TorchKbNufft package).
-    * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be 
-    assumed that the spatial frequencies are different for each channel, and the spatial
-    frequencies provided for each channel will be used (and will invoke parallelization 
-    across the image cube ``nchan`` dimension using the 'batch' dimension of the TorchKbNufft package).
+    * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that the
+        spatial frequencies can be treated as constant with channel (and will invoke
+        parallelization across the image cube ``nchan`` dimension using the 'coil' 
+        dimension of the TorchKbNufft package).
+    * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be
+        assumed that the spatial frequencies are different for each channel, and the 
+        spatial frequencies provided for each channel will be used (and will invoke 
+        parallelization across the image cube ``nchan`` dimension using the 'batch' 
+        dimension of the TorchKbNufft package).
 
-    Note that there is no straightforward, computationally efficient way to proceed if 
-    there are a different number of spatial frequencies for each channel. The best 
-    approach is likely to construct ``uu`` and ``vv`` arrays that have a shape of 
-    (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` points 
-    to have the same length ``nvis``, and you create a boolean mask to keep track of 
-    which points are valid. Then, when this routine returns data points of shape 
-    (``nchan, nvis``), you can use that boolean mask to select only the valid :math:`u,v` points.
+    Note that there is no straightforward, computationally efficient way to proceed if
+    there are a different number of spatial frequencies for each channel. The best
+    approach is likely to construct ``uu`` and ``vv`` arrays that have a shape of
+    (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` points
+    to have the same length ``nvis``, and you create a boolean mask to keep track of
+    which points are valid. Then, when this routine returns data points of shape
+    (``nchan, nvis``), you can use that boolean mask to select only the valid 
+    :math:`u,v` points.
 
-    **Interpolation mode**: You may choose the type of interpolation mode that KbNufft 
-    uses under the hood by changing the boolean value of ``sparse_matrices``. For 
-    repeated evaluations of this layer (as might exist within an optimization loop), 
-    ``sparse_matrices=True`` is likely to be the more accurate and faster choice. If 
-    ``sparse_matrices=False``, this routine will use the default table-based 
-    interpolation of TorchKbNufft. Note that as of TorchKbNuFFT version 1.4.0, sparse 
-    matrices are not yet available when parallelizing using the 'batch' dimension --- 
+    **Interpolation mode**: You may choose the type of interpolation mode that KbNufft
+    uses under the hood by changing the boolean value of ``sparse_matrices``. For
+    repeated evaluations of this layer (as might exist within an optimization loop),
+    ``sparse_matrices=True`` is likely to be the more accurate and faster choice. If
+    ``sparse_matrices=False``, this routine will use the default table-based
+    interpolation of TorchKbNufft. Note that as of TorchKbNuFFT version 1.4.0, sparse
+    matrices are not yet available when parallelizing using the 'batch' dimension ---
     this will result in a warning.
 
     Args:
         cell_size (float): the width of an image-plane pixel [arcseconds]
         npix (int): the number of pixels per image side
-        coords (GridCoords): an object already instantiated from the GridCoords class. 
+        coords (GridCoords): an object already instantiated from the GridCoords class.
             If providing this, cannot provide ``cell_size`` or ``npix``.
-        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`.
             Default = 1.
-        uu (array-like): a length ``nvis`` array (not including Hermitian pairs) of the 
+        uu (array-like): a length ``nvis`` array (not including Hermitian pairs) of the
             u (East-West) spatial frequency coordinate [klambda]
-        vv (array-like): a length ``nvis`` array (not including Hermitian pairs) of the 
+        vv (array-like): a length ``nvis`` array (not including Hermitian pairs) of the
             v (North-South) spatial frequency coordinate [klambda]
 
     """
@@ -752,27 +752,26 @@ class NuFFTCached(NuFFT):
 
     def forward(self, cube):
         r"""
-        Perform the FFT of the image cube for each channel and interpolate to the 
-        ``uu`` and ``vv`` points set at layer initialization. This call should 
-        automatically take the best parallelization option as set by the shape of the 
+        Perform the FFT of the image cube for each channel and interpolate to the
+        ``uu`` and ``vv`` points set at layer initialization. This call should
+        automatically take the best parallelization option as set by the shape of the
         ``uu`` and ``vv`` points.
 
         Args:
-            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube 
-                should be a "prepacked" image cube, for example, from 
+            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube
+                should be a "prepacked" image cube, for example, from
                 :meth:`mpol.images.ImageCube.forward`
 
         Returns:
-            torch.complex tensor: of shape ``(nchan, nvis)``, Fourier samples evaluated 
-            corresponding to the ``uu``, ``vv`` points set at initialization.
+            torch.complex tensor: of shape ``(nchan, nvis)``, Fourier samples evaluated
+                corresponding to the ``uu``, ``vv`` points set at initialization.
         """
 
         # make sure that the nchan assumptions for the ImageCube and the NuFFT
         # setup are the same
         if cube.size(0) != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of ImageCube ({cube.size(0)}) is different than that used to 
-                initialize NuFFT layer ({self.nchan})"
+                f"nchan of ImageCube ({cube.size(0)}) is different than that used to initialize NuFFT layer ({self.nchan})"
             )
 
         # "unpack" the cube, but leave it flipped
@@ -827,26 +826,26 @@ def make_fake_data(
     weight: NDArray[floating[Any]],
 ) -> tuple[NDArray[complexfloating[Any, Any]], ...]:
     r"""
-    Create a fake dataset from a supplied :class:`mpol.images.ImageCube`. See 
-    :ref:`mock-dataset-label` for more details on how to prepare a generic image for 
+    Create a fake dataset from a supplied :class:`mpol.images.ImageCube`. See
+    :ref:`mock-dataset-label` for more details on how to prepare a generic image for
     use in an :class:`~mpol.images.ImageCube`.
 
-    The provided visibilities can be 1d for a single continuum channel, or 2d for 
-    image cube. If 1d, visibilities will be converted to 2d arrays of shape 
+    The provided visibilities can be 1d for a single continuum channel, or 2d for
+    image cube. If 1d, visibilities will be converted to 2d arrays of shape
     ``(1, nvis)``.
 
     Args:
-        imageCube (:class:`~mpol.images.ImageCube`): the image layer to put into a 
+        imageCube (:class:`~mpol.images.ImageCube`): the image layer to put into a
             fake dataset
-        uu (numpy array): array of u spatial frequency coordinates, not including   
+        uu (numpy array): array of u spatial frequency coordinates, not including
             Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): array of v spatial frequency coordinates, not including 
+        vv (numpy array): array of v spatial frequency coordinates, not including
             Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
-        weight (2d numpy array): length array of thermal weights 
+        weight (2d numpy array): length array of thermal weights
             :math:`w_i = 1/\sigma_i^2`. Units of [:math:`1/\mathrm{Jy}^2`]
 
     Returns:
-        (2-tuple): a two tuple of the fake data. The first array is the mock dataset 
+        (2-tuple): a two tuple of the fake data. The first array is the mock dataset
         including noise, the second array is the mock dataset without added noise.
     """
 

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -1,4 +1,5 @@
-r"""The ``fourier`` module provides the core functionality of MPoL via :class:`mpol.fourier.FourierCube`."""
+r"""The ``fourier`` module provides the core functionality of MPoL via 
+:class:`mpol.fourier.FourierCube`."""
 
 from __future__ import annotations
 
@@ -22,11 +23,19 @@ from .coordinates import GridCoords
 
 class FourierCube(nn.Module):
     r"""
-    This layer performs the FFT of an ImageCube and stores the corresponding dense FFT output as a cube. If you are using this layer in a forward-modeling RML workflow, because the FFT of the model is essentially stored as a grid, you will need to make the loss function calculation using a gridded loss function (e.g., :func:`mpol.losses.nll_gridded`) and a gridded dataset (e.g., :class:`mpol.datasets.GriddedDataset`).
+    This layer performs the FFT of an ImageCube and stores the corresponding dense FFT 
+    output as a cube. If you are using this layer in a forward-modeling RML workflow, 
+    because the FFT of the model is essentially stored as a grid, you will need to make 
+    the loss function calculation using a gridded loss function (e.g., 
+    :func:`mpol.losses.nll_gridded`) and a gridded dataset (e.g., 
+    :class:`mpol.datasets.GriddedDataset`).
 
     Args:
         coords (GridCoords): an object already instantiated from the GridCoords class.
-        persistent_vis (Boolean): should the visibility cube be stored as part of the modules `state_dict`? If `True`, the state of the UV grid will be stored. It is recommended to use `False` for most applications, since the visibility cube will rarely be a direct parameter of the model.
+        persistent_vis (Boolean): should the visibility cube be stored as part of the 
+        modules `state_dict`? If `True`, the state of the UV grid will be stored. It is 
+        recommended to use `False` for most applications, since the visibility cube will
+          rarely be a direct parameter of the model.
 
     """
 
@@ -50,12 +59,16 @@ class FourierCube(nn.Module):
         cls, cell_size: float, npix: int, persistent_vis: bool = False
     ) -> FourierCube:
         """
-        Alternative method for instantiating a FourierCube from ``cell_size`` and ``npix``
+        Alternative method for instantiating a FourierCube from ``cell_size`` and 
+        ``npix``
 
         Args:
             cell_size (float): the width of an image-plane pixel [arcseconds]
             npix (int): the number of pixels per image side
-            persistent_vis (Boolean): should the visibility cube be stored as part of the modules `state_dict`? If `True`, the state of the UV grid will be stored. It is recommended to use `False` for most applications, since the visibility cube will rarely be a direct parameter of the model.
+            persistent_vis (Boolean): should the visibility cube be stored as part of 
+                the modules `state_dict`? If `True`, the state of the UV grid will be 
+                stored. It is recommended to use `False` for most applications, since 
+                the visibility cube will rarely be a direct parameter of the model.
 
         Returns:
             instantiated :class:`mpol.fourier.FourierCube` object.
@@ -68,10 +81,12 @@ class FourierCube(nn.Module):
         Perform the FFT of the image cube on each channel.
 
         Args:
-            cube (torch.double tensor, of shape ``(nchan, npix, npix)``): a prepacked image cube, for example, from ImageCube.forward()
+            cube (torch.double tensor, of shape ``(nchan, npix, npix)``): a prepacked 
+            image cube, for example, from ImageCube.forward()
 
         Returns:
-            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the image cube, in packed format.
+            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the 
+            image cube, in packed format.
         """
 
         # make sure the cube is 3D
@@ -87,10 +102,12 @@ class FourierCube(nn.Module):
     @property
     def ground_vis(self) -> torch.Tensor:
         r"""
-        The visibility cube in ground format cube fftshifted for plotting with ``imshow``.
+        The visibility cube in ground format cube fftshifted for plotting with 
+        ``imshow``.
 
         Returns:
-            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the image cube, in sky plane format.
+            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the 
+            image cube, in sky plane format.
         """
 
         return utils.packed_cube_to_ground_cube(self.vis)
@@ -98,7 +115,8 @@ class FourierCube(nn.Module):
     @property
     def ground_amp(self) -> torch.Tensor:
         r"""
-        The amplitude of the cube, arranged in unpacked format corresponding to the FFT of the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
+        The amplitude of the cube, arranged in unpacked format corresponding to the FFT 
+        of the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
 
         Returns:
             torch.double : 3D amplitude cube of shape ``(nchan, npix, npix)``
@@ -108,7 +126,8 @@ class FourierCube(nn.Module):
     @property
     def ground_phase(self) -> torch.Tensor:
         r"""
-        The phase of the cube, arranged in unpacked format corresponding to the FFT of the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
+        The phase of the cube, arranged in unpacked format corresponding to the FFT of 
+        the sky_cube. Array dimensions for plotting given by ``self.coords.vis_ext``.
 
         Returns:
             torch.double : 3D phase cube of shape ``(nchan, npix, npix)``
@@ -124,27 +143,43 @@ def safe_baseline_constant_meters(
     uv_cell_frac: float = 0.05,
 ) -> bool:
     r"""
-    This routine determines whether the baselines can safely be assumed to be constant with channel when they converted from meters to units of kilolambda.
+    This routine determines whether the baselines can safely be assumed to be constant 
+    with channel when they converted from meters to units of kilolambda.
 
-    The antenna baselines *are* the same as a function of channel when they are measured in physical distance units, such as meters. However, when these baselines are converted to spatial frequency units, via
+    The antenna baselines *are* the same as a function of channel when they are measured
+      in physical distance units, such as meters. However, when these baselines are 
+      converted to spatial frequency units, via
 
     .. math::
 
         u = \frac{D}{\lambda},
 
-    it's possible that the :math:`u` and :math:`v` values of each channel are significantly different if the :math:`\lambda` values of each channel are significantly different. This routine evaluates whether the maximum change in :math:`u` or :math:`v` across channels (when represented in kilolambda) is smaller than some threshold value, calculated as the fraction of a :math:`u,v` cell defined by ``coords``.
+    it's possible that the :math:`u` and :math:`v` values of each channel are 
+    significantly different if the :math:`\lambda` values of each channel are 
+    significantly different. This routine evaluates whether the maximum change in 
+    :math:`u` or :math:`v` across channels (when represented in kilolambda) is smaller 
+    than some threshold value, calculated as the fraction of a :math:`u,v` cell defined
+    by ``coords``.
 
-    If this function returns ``True``, then it would be safe to proceed with parallelization in the :class:`mpol.fourier.NuFFT` layer via the coil dimension.
+    If this function returns ``True``, then it would be safe to proceed with 
+    parallelization in the :class:`mpol.fourier.NuFFT` layer via the coil dimension.
 
     Args:
-        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) spatial frequency coordinate in units of [m]
-        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) spatial frequency coordinate in units of [m]
-        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, in units of [Hz].
-        coords: a :class:`mpol.coordinates.GridCoords` object which represents the image and uv-grid dimensions.
-        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or :math:`v` spatial frequency across channels, measured as a fraction of the :math:`u,v` cell defined by ``coords``.
+        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) 
+            spatial frequency coordinate in units of [m]
+        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) 
+            spatial frequency coordinate in units of [m]
+        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, 
+            in units of [Hz].
+        coords: a :class:`mpol.coordinates.GridCoords` object which represents the image
+            and uv-grid dimensions.
+        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or 
+            :math:`v` spatial frequency across channels, measured as a fraction of the 
+            :math:`u,v` cell defined by ``coords``.
 
     Returns:
-        boolean: `True` if it is safe to assume that the baselines are constant with channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
+        boolean: `True` if it is safe to assume that the baselines are constant with 
+        channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
     """
 
     # broadcast and convert baselines to kilolambda across channel
@@ -177,21 +212,34 @@ def safe_baseline_constant_kilolambda(
     uv_cell_frac: float = 0.05,
 ) -> bool:
     r"""
-    This routine determines whether the baselines can safely be assumed to be constant with channel, when the are represented in units of kilolambda.
+    This routine determines whether the baselines can safely be assumed to be constant 
+    with channel, when the are represented in units of kilolambda.
 
-    Compared to :class:`mpol.fourier.safe_baseline_constant_meters`, this function works with multidimensional arrays of ``uu`` and ``vv`` that are shape (nchan, nvis) and have units of kilolambda.
+    Compared to :class:`mpol.fourier.safe_baseline_constant_meters`, this function works
+    with multidimensional arrays of ``uu`` and ``vv`` that are shape (nchan, nvis) and 
+    have units of kilolambda.
 
-    If this routine returns True, then it should be safe for the user to either average the baselines across channel or simply choose a single, representative channel. This would enable parallelization in the {class}`mpol.fourier.NuFFT` via the coil dimension.
+    If this routine returns True, then it should be safe for the user to either average 
+    the baselines across channel or simply choose a single, representative channel. This
+    would enable parallelization in the {class}`mpol.fourier.NuFFT` via the coil 
+    dimension.
 
     Args:
-        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) spatial frequency coordinate in units of [m]
-        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) spatial frequency coordinate in units of [m]
-        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, in units of [Hz].
-        coords: a :class:`mpol.coordinates.GridCoords` object which represents the image and uv-grid dimensions.
-        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or :math:`v` spatial frequency across channels, measured as a fraction of the :math:`u,v` cell defined by ``coords``.
+        uu (1D np.array): a 1D array of length ``nvis`` array of the u (East-West) 
+            spatial frequency coordinate in units of [m]
+        vv (1D np.array): a 1D array of length ``nvis`` array of the v (North-South) 
+            spatial frequency coordinate in units of [m]
+        freqs (1D np.array): a 1D array of length ``nchan`` of the channel frequencies, 
+            in units of [Hz].
+        coords: a :class:`mpol.coordinates.GridCoords` object which represents the 
+            image and uv-grid dimensions.
+        uv_cell_frac (float): the maximum threshold for a change in :math:`u` or 
+            :math:`v` spatial frequency across channels, measured as a fraction of the 
+            :math:`u,v` cell defined by ``coords``.
 
     Returns:
-        boolean: `True` if it is safe to assume that the baselines are constant with channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
+        boolean: `True` if it is safe to assume that the baselines are constant with 
+        channel (at a tolerance of ``uv_cell_frac``.) Otherwise returns `False`.
 
     """
     # convert uv_cell_frac to a kilolambda threshold
@@ -220,11 +268,19 @@ def safe_baseline_constant_kilolambda(
 # NuFFT
 class NuFFT(nn.Module):
     r"""
-    This layer translates input from an :class:`mpol.images.ImageCube` to loose, ungridded samples of the Fourier plane, corresponding to the :math:`u,v` locations provided. This layer is different than a :class:`mpol.Fourier.FourierCube` in that, rather than producing the dense cube-like output from an FFT routine, it utilizes the non-uniform FFT or 'NuFFT' to interpolate directly to discrete :math:`u,v` locations. This is implemented using the KbNufft routines of the `TorchKbNufft <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
+    This layer translates input from an :class:`mpol.images.ImageCube` to loose, 
+    ungridded samples of the Fourier plane, corresponding to the :math:`u,v` locations 
+    provided. This layer is different than a :class:`mpol.Fourier.FourierCube` in that, 
+    rather than producing the dense cube-like output from an FFT routine, it utilizes 
+    the non-uniform FFT or 'NuFFT' to interpolate directly to discrete :math:`u,v` 
+    locations. This is implemented using the KbNufft routines of the `TorchKbNufft 
+    <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
 
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. Default = 1.
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+            Default = 1.
     """
 
     def __init__(
@@ -250,12 +306,14 @@ class NuFFT(nn.Module):
         nchan: int = 1,
     ):
         """
-        Instantiate a :class:`mpol.fourier.NuFFT` object from image properties rather than a :meth:`mpol.coordinates.GridCoords` instance.
+        Instantiate a :class:`mpol.fourier.NuFFT` object from image properties rather 
+        than a :meth:`mpol.coordinates.GridCoords` instance.
 
         Args:
             cell_size (float): the width of an image-plane pixel [arcseconds]
             npix (int): the number of pixels per image side
-            nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. Default = 1.
+            nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+                Default = 1.
 
         Returns:
             an instance of the :class:`mpol.fourier.NuFFT`
@@ -267,7 +325,8 @@ class NuFFT(nn.Module):
         )
 
     def _klambda_to_radpix(self, klambda: torch.Tensor) -> torch.Tensor:
-        """Convert a spatial frequency in units of klambda to 'radians/sky pixel,' using the pixel cell_size provided by ``self.coords.dl``.
+        """Convert a spatial frequency in units of klambda to 'radians/sky pixel,' 
+        using the pixel cell_size provided by ``self.coords.dl``.
 
         Args:
             klambda (torch.Tensor): spatial frequency in units of klambda.
@@ -275,12 +334,30 @@ class NuFFT(nn.Module):
         Returns:
             torch.Tensor: spatial frequency measured in units of radian per sky pixel
 
-        These concepts can be a little confusing because there are two angular measures at play.
+        These concepts can be a little confusing because there are two angular measures 
+        at play.
 
-        1. The first is the normal angular sky coordinate, normally measured in arcseconds for typical sources observed by ALMA or the VLA. Arcseconds, being an angular coordinate, can equivalently be expressed in units of radians. To avoid confusion, we will call this angular measurement 'sky radians.' Alternatively, for a given image grid, this same sky coordinate could be expressed in units of sky pixels.
-        2. The second is the spatial frequency of some image-plane function, :math:`I_\nu(l,m)`, which we could quote in units of 'cycles per arcsecond' or 'cycles per sky pixel,' for example. With a radio interferometer, spatial frequencies are typically quoted in units of the observing wavelength, i.e., lambda or kilo-lambda. If the field of view of the image is small, thanks to the small-angle approximation, units of lambda are directly equivalent to 'cycles per sky radian.' The second angular measure comes about when converting the spatial frequency from a linear measure of frequency 'cycles per sky radian' to an angular measure of frequency 'radians per sky radian' or 'radians per sky pixel.'
+        1. The first is the normal angular sky coordinate, normally measured in 
+        arcseconds for typical sources observed by ALMA or the VLA. Arcseconds, being 
+        an angular coordinate, can equivalently be expressed in units of radians. To 
+        avoid confusion, we will call this angular measurement 'sky radians.' 
+        Alternatively, for a given image grid, this same sky coordinate could be 
+        expressed in units of sky pixels.
+        2. The second is the spatial frequency of some image-plane function, 
+        :math:`I_\nu(l,m)`, which we could quote in units of 'cycles per arcsecond' or 
+        'cycles per sky pixel,' for example. With a radio interferometer, spatial 
+        frequencies are typically quoted in units of the observing wavelength, i.e., 
+        lambda or kilo-lambda. If the field of view of the image is small, thanks to 
+        the small-angle approximation, units of lambda are directly equivalent to 
+        'cycles per sky radian.' The second angular measure comes about when converting 
+        the spatial frequency from a linear measure of frequency 'cycles per sky radian'
+        to an angular measure of frequency 'radians per sky radian' or 'radians per 
+        sky pixel.'
 
-        The TorchKbNufft package expects k-trajectory vectors in units of 'radians per sky pixel.' This routine helps convert spatial frequencies from their default unit (kilolambda) into 'radians per sky pixel' using the pixel cell_size as provided by ``self.coords.dl``.
+        The TorchKbNufft package expects k-trajectory vectors in units of 'radians per 
+        sky pixel.' This routine helps convert spatial frequencies from their default
+        unit (kilolambda) into 'radians per sky pixel' using the pixel cell_size as 
+        provided by ``self.coords.dl``.
         """
 
         # convert from kilolambda to cycles per sky radian
@@ -299,14 +376,27 @@ class NuFFT(nn.Module):
 
     def _assemble_ktraj(self, uu: torch.Tensor, vv: torch.Tensor) -> torch.Tensor:
         r"""
-        This routine converts a series of :math:`u, v` coordinates into a k-trajectory vector for the torchkbnufft routines. The dimensionality of the k-trajectory vector will influence how TorchKbNufft will perform the operations.
+        This routine converts a series of :math:`u, v` coordinates into a k-trajectory 
+        vector for the torchkbnufft routines. The dimensionality of the k-trajectory 
+        vector will influence how TorchKbNufft will perform the operations.
 
-        * If ``uu`` and ``vv`` have a 1D shape of (``nvis``), then it will be assumed that the spatial frequencies can be treated as constant with channel. This will result in a ``k_traj`` vector that has shape (``2, nvis``), such that parallelization will be across the image cube ``nchan`` dimension using the 'coil' dimension of the TorchKbNufft package.
-        * If the ``uu`` and ``vv`` have a 2D shape of (``nchan, nvis``), then it will be assumed that the spatial frequencies are different for each channel, and the spatial frequencies provided for each channel will be used. This will result in a ``k_traj`` vector that has shape (``nchan, 2, nvis``), such that parallelization will be across the image cube ``nchan`` dimension using the 'batch' dimension of the TorchKbNufft package.
+        * If ``uu`` and ``vv`` have a 1D shape of (``nvis``), then it will be assumed 
+        that the spatial frequencies can be treated as constant with channel. This will 
+        result in a ``k_traj`` vector that has shape (``2, nvis``), such that 
+        parallelization will be across the image cube ``nchan`` dimension using the 
+        'coil' dimension of the TorchKbNufft package.
+        * If the ``uu`` and ``vv`` have a 2D shape of (``nchan, nvis``), then it will 
+        be assumed that the spatial frequencies are different for each channel, and the 
+        spatial frequencies provided for each channel will be used. This will result in 
+        a ``k_traj`` vector that has shape (``nchan, 2, nvis``), such that 
+        parallelization will be across the image cube ``nchan`` dimension using the 
+        'batch' dimension of the TorchKbNufft package.
 
         Args:
-            uu (1D or 2D torch.Tensor array): u (East-West) spatial frequency coordinate [klambda]
-            vv (1D or 2D torch.Tensor array): v (North-South) spatial frequency coordinate [klambda]
+            uu (1D or 2D torch.Tensor array): u (East-West) spatial frequency 
+                coordinate [klambda]
+            vv (1D or 2D torch.Tensor array): v (North-South) spatial frequency 
+                coordinate [klambda]
 
         Returns:
             k_traj (torch.Tensor): a k-trajectory vector with shape
@@ -323,7 +413,8 @@ class NuFFT(nn.Module):
         if same_uv:
             # k-trajectory needs to be packed the way the image is packed (y,x), so
             # the trajectory needs to be packed (v, u)
-            # if TorchKbNufft receives a k-traj tensor of shape (2, nvis), it will parallelize across the coil dimension, assuming
+            # if TorchKbNufft receives a k-traj tensor of shape (2, nvis), 
+            # it will parallelize across the coil dimension, assuming
             # that the k-traj is the same for all coils/channels.
             # interim convert to numpy array because of torch warning about speed
             # k_traj = torch.tensor(np.array([vv_radpix, uu_radpix]))
@@ -337,17 +428,20 @@ class NuFFT(nn.Module):
         # then, concatenate the tensors along the axis=1 dimension.
         if uu_radpix.shape[0] != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of uu ({uu_radpix.shape[0]}) is more than one but different than that used to initialize the NuFFT layer ({self.nchan})"
+                f"nchan of uu ({uu_radpix.shape[0]}) is more than one but different than
+                that used to initialize the NuFFT layer ({self.nchan})"
             )
 
         if vv_radpix.shape[0] != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of vv ({vv_radpix.shape[0]}) is more than one but different than that used to initialize the NuFFT layer ({self.nchan})"
+                f"nchan of vv ({vv_radpix.shape[0]}) is more than one but different than
+                that used to initialize the NuFFT layer ({self.nchan})"
             )
 
         uu_radpix_aug = torch.unsqueeze(torch.tensor(uu_radpix), 1)
         vv_radpix_aug = torch.unsqueeze(torch.tensor(vv_radpix), 1)
-        # if TorchKbNufft receives a k-traj tensor of shape (nbatch, 2, nvis), it will parallelize across the batch dimension
+        # if TorchKbNufft receives a k-traj tensor of shape (nbatch, 2, nvis), it will 
+        # parallelize across the batch dimension
         k_traj = torch.cat([vv_radpix_aug, uu_radpix_aug], dim=1)
 
         return k_traj
@@ -360,35 +454,86 @@ class NuFFT(nn.Module):
         sparse_matrices: bool = False,
     ) -> torch.Tensor:
         r"""
-        Perform the FFT of the image cube for each channel and interpolate to the ``uu`` and ``vv`` points. This call should automatically take the best parallelization option as indicated by the shape of the ``uu`` and ``vv`` points. In general, you probably do not want to provide baselines that include Hermitian pairs.
+        Perform the FFT of the image cube for each channel and interpolate to the ``uu``
+        and ``vv`` points. This call should automatically take the best 
+        parallelization option as indicated by the shape of the ``uu`` and ``vv`` 
+        points. In general, you probably do not want to provide baselines that include 
+        Hermitian pairs.
 
         Args:
-            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube should be a "prepacked" image cube, for example, from :meth:`mpol.images.ImageCube.forward`
-            uu (array-like): array of the u (East-West) spatial frequency coordinate [klambda].
-            vv (array-like): array of the v (North-South) spatial frequency coordinate [klambda] (must be the same shape as uu)
-            sparse_matrices (bool): If False, use the default table-based interpolation of TorchKbNufft.If True, use TorchKbNuFFT sparse matrices (generally slower but more accurate).  Note that sparse matrices are incompatible with multi-channel `uu` and `vv` arrays (see below).
+            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube 
+                should be a "prepacked" image cube, for example, 
+                from :meth:`mpol.images.ImageCube.forward`
+            uu (array-like): array of the u (East-West) spatial frequency coordinate 
+                [klambda].
+            vv (array-like): array of the v (North-South) spatial frequency coordinate 
+                [klambda] (must be the same shape as uu)
+            sparse_matrices (bool): If False, use the default table-based interpolation 
+                of TorchKbNufft.If True, use TorchKbNuFFT sparse matrices (generally 
+                slower but more accurate).  Note that sparse matrices are incompatible 
+                with multi-channel `uu` and `vv` arrays (see below).
 
         Returns:
-            torch.complex tensor: Fourier samples of shape ``(nchan, nvis)``, evaluated at the ``uu``, ``vv`` points
+            torch.complex tensor: Fourier samples of shape ``(nchan, nvis)``, evaluated 
+            at the ``uu``, ``vv`` points
 
-        **Dimensionality**: You should consider the dimensionality of your image and your visibility samples when using this method. If your image has multiple channels (``nchan > 1``), there is the possibility that the :math:`u,v` sample locations corresponding to each channel may be different. In ALMA/VLA applications, this can arise when continuum observations are taken over significant bandwidth, since the spatial frequency sampled by any pair of antennas is wavelength-dependent
+        **Dimensionality**: You should consider the dimensionality of your image and 
+        your visibility samples when using this method. If your image has multiple 
+        channels (``nchan > 1``), there is the possibility that the :math:`u,v` sample 
+        locations corresponding to each channel may be different. In ALMA/VLA 
+        applications, this can arise when continuum observations are taken over 
+        significant bandwidth, since the spatial frequency sampled by any pair of 
+        antennas is wavelength-dependent
 
         .. math::
 
             u = \frac{D}{\lambda},
 
-        where :math:`D` is the projected baseline (measured in, say, meters) and :math:`\lambda` is the observing wavelength. In this application, the image-plane model could be the same for each channel, or it may vary with channel (necessary if the spectral slope of the source is significant).
+        where :math:`D` is the projected baseline (measured in, say, meters) and 
+        :math:`\lambda` is the observing wavelength. In this application, the 
+        image-plane model could be the same for each channel, or it may vary with
+        channel (necessary if the spectral slope of the source is significant).
 
-        On the other hand, with spectral line observations it will usually be the case that the total bandwidth of the observations is small enough such that the :math:`u,v` sample locations could be considered as the same for each channel. In spectral line applications, the image-plane model usually varies substantially with each channel.
+        On the other hand, with spectral line observations it will usually be the case 
+        that the total bandwidth of the observations is small enough such that the 
+        :math:`u,v` sample locations could be considered as the same for each channel. 
+        In spectral line applications, the image-plane model usually varies 
+        substantially with each channel.
 
-        This routine will determine whether the spatial frequencies are treated as constant based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
+        This routine will determine whether the spatial frequencies are treated as 
+        constant based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
 
-        * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that the spatial frequencies can be treated as constant with channel (and will invoke parallelization across the image cube ``nchan`` dimension using the 'coil' dimension of the TorchKbNufft package).
-        * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be assumed that the spatial frequencies are different for each channel, and the spatial frequencies provided for each channel will be used (and will invoke parallelization across the image cube ``nchan`` dimension using the 'batch' dimension of the TorchKbNufft package).
+        * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that 
+        the spatial frequencies can be treated as constant with channel (and will invoke
+        parallelization across the image cube ``nchan`` dimension using the 'coil' 
+        dimension of the TorchKbNufft package).
+        * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be 
+        assumed that the spatial frequencies are different for each channel, and the 
+        spatial frequencies provided for each channel will be used (and will invoke 
+        parallelization across the image cube ``nchan`` dimension using the 'batch' 
+        dimension of the TorchKbNufft package).
 
-        Note that there is no straightforward, computationally efficient way to proceed if there are a different number of spatial frequencies for each channel. The best approach is likely to construct ``uu`` and ``vv`` arrays that have a shape of (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` points to have the same length ``nvis``, and you create a boolean mask to keep track of which points are valid. Then, when this routine returns data points of shape (``nchan, nvis``), you can use that boolean mask to select only the valid :math:`u,v` points points.
+        Note that there is no straightforward, computationally efficient way to proceed 
+        if there are a different number of spatial frequencies for each channel. The 
+        best approach is likely to construct ``uu`` and ``vv`` arrays that have a shape 
+        of (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` 
+        points to have the same length ``nvis``, and you create a boolean mask to keep 
+        track of which points are valid. Then, when this routine returns data points of 
+        shape (``nchan, nvis``), you can use that boolean mask to select only the valid 
+        :math:`u,v` points points.
 
-        **Interpolation mode**: You may choose the type of interpolation mode that KbNufft uses under the hood by changing the boolean value of ``sparse_matrices``. If ``sparse_matrices=False``, this routine will use the default table-based interpolation of TorchKbNufft. If ``sparse_matrices=True``, the routine will calculate sparse matrices (which can be stored for later operations, as in {class}`~mpol.fourier.NuFFTCached`) and use them for the interpolation. This approach is likely to be more accurate but also slower. If Note that as of TorchKbNuFFT version 1.4.0, sparse matrices are not yet available when parallelizing using the 'batch' dimension --- this will result in a warning. For most applications, we anticipate the accuracy of the table-based interpolation to be sufficiently accurate, but this could change depending on your problem.
+        **Interpolation mode**: You may choose the type of interpolation mode that 
+        KbNufft uses under the hood by changing the boolean value of 
+        ``sparse_matrices``. If ``sparse_matrices=False``, this routine will use the 
+        default table-based interpolation of TorchKbNufft. If ``sparse_matrices=True``, 
+        the routine will calculate sparse matrices (which can be stored for later 
+        operations, as in {class}`~mpol.fourier.NuFFTCached`) and use them for the 
+        interpolation. This approach is likely to be more accurate but also slower. If 
+        Note that as of TorchKbNuFFT version 1.4.0, sparse matrices are not yet 
+        available when parallelizing using the 'batch' dimension --- this will result 
+        in a warning. For most applications, we anticipate the accuracy of the 
+        table-based interpolation to be sufficiently accurate, but this could change 
+        depending on your problem.
         """
 
         # permit numpy, but prefer tensor
@@ -399,7 +544,8 @@ class NuFFT(nn.Module):
         # setup are the same
         if cube.size(0) != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of ImageCube ({cube.size(0)}) is different than that used to initialize NuFFT layer ({self.nchan})"
+                f"nchan of ImageCube ({cube.size(0)}) is different than that used to 
+                initialize NuFFT layer ({self.nchan})"
             )
 
         # "unpack" the cube, but leave it flipped
@@ -474,34 +620,76 @@ class NuFFT(nn.Module):
 
 class NuFFTCached(NuFFT):
     r"""
-    This layer translates input from an :class:`mpol.images.ImageCube` directly to loose, ungridded samples of the Fourier plane, directly corresponding to the :math:`u,v` locations of the data. This layer is different than a :class:`mpol.Fourier.FourierCube` in that, rather than producing the dense cube-like output from an FFT routine, it utilizes the non-uniform FFT or 'NuFFT' to interpolate directly to discrete :math:`u,v` locations that need not correspond to grid cell centers. This is implemented using the KbNufft routines of the `TorchKbNufft <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
+    This layer translates input from an :class:`mpol.images.ImageCube` directly to 
+    loose, ungridded samples of the Fourier plane, directly corresponding to the 
+    :math:`u,v` locations of the data. This layer is different than a 
+    :class:`mpol.Fourier.FourierCube` in that, rather than producing the dense cube-like
+    output from an FFT routine, it utilizes the non-uniform FFT or 'NuFFT' to 
+    interpolate directly to discrete :math:`u,v` locations that need not correspond to 
+    grid cell centers. This is implemented using the KbNufft routines of the 
+    `TorchKbNufft <https://torchkbnufft.readthedocs.io/en/stable/index.html>`_ package.
 
-    **Dimensionality**: One consideration when using this layer is the dimensionality of your image and your visibility samples. If your image has multiple channels (``nchan > 1``), there is the possibility that the :math:`u,v` sample locations corresponding to each channel may be different. In ALMA/VLA applications, this can arise when continuum observations are taken over significant bandwidth, since the spatial frequency sampled by any pair of antennas is wavelength-dependent
+    **Dimensionality**: One consideration when using this layer is the dimensionality of
+    your image and your visibility samples. If your image has multiple channels 
+    (``nchan > 1``), there is the possibility that the :math:`u,v` sample locations 
+    corresponding to each channel may be different. In ALMA/VLA applications, this can 
+    arise when continuum observations are taken over significant bandwidth, since the 
+    spatial frequency sampled by any pair of antennas is wavelength-dependent
 
     .. math::
 
         u = \frac{D}{\lambda},
 
-    where :math:`D` is the projected baseline (measured in, say, meters) and :math:`\lambda` is the observing wavelength. In this application, the image-plane model could be the same for each channel, or it may vary with channel (necessary if the spectral slope of the source is significant).
+    where :math:`D` is the projected baseline (measured in, say, meters) and 
+    :math:`\lambda` is the observing wavelength. In this application, the image-plane 
+    model could be the same for each channel, or it may vary with channel (necessary if 
+    the spectral slope of the source is significant).
 
-    On the other hand, with spectral line observations it will usually be the case that the total bandwidth of the observations is small enough such that the :math:`u,v` sample locations could be considered as the same for each channel. In spectral line applications, the image-plane model usually varies substantially with each channel.
+    On the other hand, with spectral line observations it will usually be the case that 
+    the total bandwidth of the observations is small enough such that the :math:`u,v` 
+    sample locations could be considered as the same for each channel. In spectral line 
+    applications, the image-plane model usually varies substantially with each channel.
 
-    This layer will determine whether the spatial frequencies are treated as constant based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
+    This layer will determine whether the spatial frequencies are treated as constant 
+    based upon the dimensionality of the ``uu`` and ``vv`` input arguments.
 
-    * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that the spatial frequencies can be treated as constant with channel (and will invoke parallelization across the image cube ``nchan`` dimension using the 'coil' dimension of the TorchKbNufft package).
-    * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be assumed that the spatial frequencies are different for each channel, and the spatial frequencies provided for each channel will be used (and will invoke parallelization across the image cube ``nchan`` dimension using the 'batch' dimension of the TorchKbNufft package).
+    * If ``uu`` and ``vv`` have a shape of (``nvis``), then it will be assumed that the 
+    spatial frequencies can be treated as constant with channel (and will invoke 
+    parallelization across the image cube ``nchan`` dimension using the 'coil' dimension
+    of the TorchKbNufft package).
+    * If the ``uu`` and ``vv`` have a shape of (``nchan, nvis``), then it will be 
+    assumed that the spatial frequencies are different for each channel, and the spatial
+    frequencies provided for each channel will be used (and will invoke parallelization 
+    across the image cube ``nchan`` dimension using the 'batch' dimension of the TorchKbNufft package).
 
-    Note that there is no straightforward, computationally efficient way to proceed if there are a different number of spatial frequencies for each channel. The best approach is likely to construct ``uu`` and ``vv`` arrays that have a shape of (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` points to have the same length ``nvis``, and you create a boolean mask to keep track of which points are valid. Then, when this routine returns data points of shape (``nchan, nvis``), you can use that boolean mask to select only the valid :math:`u,v` points.
+    Note that there is no straightforward, computationally efficient way to proceed if 
+    there are a different number of spatial frequencies for each channel. The best 
+    approach is likely to construct ``uu`` and ``vv`` arrays that have a shape of 
+    (``nchan, nvis``), such that all channels are padded with bogus :math:`u,v` points 
+    to have the same length ``nvis``, and you create a boolean mask to keep track of 
+    which points are valid. Then, when this routine returns data points of shape 
+    (``nchan, nvis``), you can use that boolean mask to select only the valid :math:`u,v` points.
 
-    **Interpolation mode**: You may choose the type of interpolation mode that KbNufft uses under the hood by changing the boolean value of ``sparse_matrices``. For repeated evaluations of this layer (as might exist within an optimization loop), ``sparse_matrices=True`` is likely to be the more accurate and faster choice. If ``sparse_matrices=False``, this routine will use the default table-based interpolation of TorchKbNufft. Note that as of TorchKbNuFFT version 1.4.0, sparse matrices are not yet available when parallelizing using the 'batch' dimension --- this will result in a warning.
+    **Interpolation mode**: You may choose the type of interpolation mode that KbNufft 
+    uses under the hood by changing the boolean value of ``sparse_matrices``. For 
+    repeated evaluations of this layer (as might exist within an optimization loop), 
+    ``sparse_matrices=True`` is likely to be the more accurate and faster choice. If 
+    ``sparse_matrices=False``, this routine will use the default table-based 
+    interpolation of TorchKbNufft. Note that as of TorchKbNuFFT version 1.4.0, sparse 
+    matrices are not yet available when parallelizing using the 'batch' dimension --- 
+    this will result in a warning.
 
     Args:
         cell_size (float): the width of an image-plane pixel [arcseconds]
         npix (int): the number of pixels per image side
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. Default = 1.
-        uu (array-like): a length ``nvis`` array (not including Hermitian pairs) of the u (East-West) spatial frequency coordinate [klambda]
-        vv (array-like): a length ``nvis`` array (not including Hermitian pairs) of the v (North-South) spatial frequency coordinate [klambda]
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        nchan (int): the number of channels in the :class:`mpol.images.ImageCube`. 
+            Default = 1.
+        uu (array-like): a length ``nvis`` array (not including Hermitian pairs) of the 
+            u (East-West) spatial frequency coordinate [klambda]
+        vv (array-like): a length ``nvis`` array (not including Hermitian pairs) of the 
+            v (North-South) spatial frequency coordinate [klambda]
 
     """
 
@@ -564,20 +752,27 @@ class NuFFTCached(NuFFT):
 
     def forward(self, cube):
         r"""
-        Perform the FFT of the image cube for each channel and interpolate to the ``uu`` and ``vv`` points set at layer initialization. This call should automatically take the best parallelization option as set by the shape of the ``uu`` and ``vv`` points.
+        Perform the FFT of the image cube for each channel and interpolate to the 
+        ``uu`` and ``vv`` points set at layer initialization. This call should 
+        automatically take the best parallelization option as set by the shape of the 
+        ``uu`` and ``vv`` points.
 
         Args:
-            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube should be a "prepacked" image cube, for example, from :meth:`mpol.images.ImageCube.forward`
+            cube (torch.double tensor): of shape ``(nchan, npix, npix)``). The cube 
+                should be a "prepacked" image cube, for example, from 
+                :meth:`mpol.images.ImageCube.forward`
 
         Returns:
-            torch.complex tensor: of shape ``(nchan, nvis)``, Fourier samples evaluated corresponding to the ``uu``, ``vv`` points set at initialization.
+            torch.complex tensor: of shape ``(nchan, nvis)``, Fourier samples evaluated 
+            corresponding to the ``uu``, ``vv`` points set at initialization.
         """
 
         # make sure that the nchan assumptions for the ImageCube and the NuFFT
         # setup are the same
         if cube.size(0) != self.nchan:
             raise DimensionMismatchError(
-                f"nchan of ImageCube ({cube.size(0)}) is different than that used to initialize NuFFT layer ({self.nchan})"
+                f"nchan of ImageCube ({cube.size(0)}) is different than that used to 
+                initialize NuFFT layer ({self.nchan})"
             )
 
         # "unpack" the cube, but leave it flipped
@@ -632,18 +827,27 @@ def make_fake_data(
     weight: NDArray[floating[Any]],
 ) -> tuple[NDArray[complexfloating[Any, Any]], ...]:
     r"""
-    Create a fake dataset from a supplied :class:`mpol.images.ImageCube`. See :ref:`mock-dataset-label` for more details on how to prepare a generic image for use in an :class:`~mpol.images.ImageCube`.
+    Create a fake dataset from a supplied :class:`mpol.images.ImageCube`. See 
+    :ref:`mock-dataset-label` for more details on how to prepare a generic image for 
+    use in an :class:`~mpol.images.ImageCube`.
 
-    The provided visibilities can be 1d for a single continuum channel, or 2d for image cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``.
+    The provided visibilities can be 1d for a single continuum channel, or 2d for 
+    image cube. If 1d, visibilities will be converted to 2d arrays of shape 
+    ``(1, nvis)``.
 
     Args:
-        imageCube (:class:`~mpol.images.ImageCube`): the image layer to put into a fake dataset
-        uu (numpy array): array of u spatial frequency coordinates, not including Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): array of v spatial frequency coordinates, not including Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
-        weight (2d numpy array): length array of thermal weights :math:`w_i = 1/\sigma_i^2`. Units of [:math:`1/\mathrm{Jy}^2`]
+        imageCube (:class:`~mpol.images.ImageCube`): the image layer to put into a 
+            fake dataset
+        uu (numpy array): array of u spatial frequency coordinates, not including   
+            Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
+        vv (numpy array): array of v spatial frequency coordinates, not including 
+            Hermitian pairs. Units of [:math:`\mathrm{k}\lambda`]
+        weight (2d numpy array): length array of thermal weights 
+            :math:`w_i = 1/\sigma_i^2`. Units of [:math:`1/\mathrm{Jy}^2`]
 
     Returns:
-        (2-tuple): a two tuple of the fake data. The first array is the mock dataset including noise, the second array is the mock dataset without added noise.
+        (2-tuple): a two tuple of the fake data. The first array is the mock dataset 
+        including noise, the second array is the mock dataset without added noise.
     """
 
     # instantiate a NuFFT object based on the ImageCube

--- a/src/mpol/geometry.py
+++ b/src/mpol/geometry.py
@@ -6,9 +6,12 @@ import torch
 
 
 def flat_to_observer(x, y, omega=None, incl=None, Omega=None):
-    """Rotate the frame to convert a point in the flat (x,y,z) frame to observer frame (X,Y,Z).
+    """Rotate the frame to convert a point in the flat (x,y,z) frame to observer frame 
+    (X,Y,Z).
 
-    It is assumed that the +Z axis points *towards* the observer. It is assumed that the model is flat in the (x,y) frame (like a flat disk), and so the operations involving ``z`` are neglected. But the model lives in 3D Cartesian space.
+    It is assumed that the +Z axis points *towards* the observer. It is assumed that the
+      model is flat in the (x,y) frame (like a flat disk), and so the operations 
+      involving ``z`` are neglected. But the model lives in 3D Cartesian space.
 
     In order,
 
@@ -16,21 +19,30 @@ def flat_to_observer(x, y, omega=None, incl=None, Omega=None):
     2. rotate about the x1 axis by an amount -incl -> x2, y2, z2
     3. rotate about the z2 axis by an amount Omega -> x3, y3, z3 = X, Y, Z
 
-    Inspired by `exoplanet/keplerian.py <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
+    Inspired by `exoplanet/keplerian.py 
+    <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
 
     Args:
-        x (torch tensor): A tensor representing the x coordinate in the plane of the orbit.
-        y (torch tensor): A tensor representing the y coordinate in the plane of the orbit.
-        omega (torch float tensor): A tensor representing an argument of periastron [radians] Default 0.0.
-        incl (torch float tensor): A tensor representing an inclination value [radians]. Default 0.0.
-        Omega (torch float tensor): A tensor representing the position angle of the ascending node in [radians]. Default 0.0
+        x (torch tensor): A tensor representing the x coordinate in the plane of 
+            the orbit.
+        y (torch tensor): A tensor representing the y coordinate in the plane of 
+            the orbit.
+        omega (torch float tensor): A tensor representing an argument of periastron 
+            [radians] Default 0.0.
+        incl (torch float tensor): A tensor representing an inclination value [radians].
+            Default 0.0.
+        Omega (torch float tensor): A tensor representing the position angle of the 
+            ascending node in [radians]. Default 0.0
 
     Returns:
         Two tensors representing ``(X, Y)`` in the observer frame.
     """
-    # Rotation matrices result in a *clockwise* rotation of the axes, as defined using the righthand rule.
-    # For example, looking down the z-axis, a positive angle will rotate the x,y axes clockwise.
-    # A vector in the coordinate system will appear as though it has been rotated counter-clockwise.
+    # Rotation matrices result in a *clockwise* rotation of the axes, 
+    # as defined using the righthand rule.
+    # For example, looking down the z-axis, 
+    # a positive angle will rotate the x,y axes clockwise.
+    # A vector in the coordinate system will appear as though it has been 
+    # rotated counter-clockwise.
 
     # 1) rotate about the z0 axis by omega
     if omega is not None:
@@ -69,9 +81,11 @@ def flat_to_observer(x, y, omega=None, incl=None, Omega=None):
 
 
 def observer_to_flat(X, Y, omega=None, incl=None, Omega=None):
-    """Rotate the frame to convert a point in the observer frame (X,Y,Z) to the flat (x,y,z) frame.
+    """Rotate the frame to convert a point in the observer frame (X,Y,Z) to the 
+    flat (x,y,z) frame.
 
-    It is assumed that the +Z axis points *towards* the observer. The rotation operations are the inverse of the :func:`~mpol.geometry.flat_to_observer` operations.
+    It is assumed that the +Z axis points *towards* the observer. The rotation 
+    operations are the inverse of the :func:`~mpol.geometry.flat_to_observer` operations.
 
     In order,
 
@@ -79,21 +93,30 @@ def observer_to_flat(X, Y, omega=None, incl=None, Omega=None):
     2. inverse rotation about the x2 axis by an amount -incl -> x1, y1, z1
     3. inverse rotation about the z1 axis by an amount omega -> x, y, z
 
-    Inspired by `exoplanet/keplerian.py <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
+    Inspired by `exoplanet/keplerian.py 
+    <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
 
     Args:
-        X (torch tensor): A tensor representing the x coodinate in the plane of the orbit.
-        Y (torch.tensor): A tensor representing the y coodinate in the plane of the orbit.
-        omega (torch float tensor): A tensor representing an argument of periastron [radians] Default 0.0.
-        incl (torch float tensor): A tensor representing an inclination value [radians]. Default 0.0.
-        Omega (torch float tensor): A tensor representing the position angle of the ascending node in [radians]. Default 0.0
+        X (torch tensor): A tensor representing the x coodinate in the plane of 
+            the orbit.
+        Y (torch.tensor): A tensor representing the y coodinate in the plane of 
+            the orbit.
+        omega (torch float tensor): A tensor representing an argument of periastron 
+            [radians] Default 0.0.
+        incl (torch float tensor): A tensor representing an inclination value [radians].
+            Default 0.0.
+        Omega (torch float tensor): A tensor representing the position angle of the 
+            ascending node in [radians]. Default 0.0
 
     Returns:
         Two tensors representing ``(x, y)`` in the flat frame.
     """
-    # Rotation matrices result in a *clockwise* rotation of the axes, as defined using the righthand rule.
-    # For example, looking down the z-axis, a positive angle will rotate the x,y axes clockwise.
-    # A vector in the coordinate system will appear as though it has been rotated counter-clockwise.
+    # Rotation matrices result in a *clockwise* rotation of the axes, 
+    # as defined using the righthand rule.
+    # For example, looking down the z-axis, a positive angle will rotate the 
+    # x,y axes clockwise.
+    # A vector in the coordinate system will appear as though it has been 
+    # rotated counter-clockwise.
 
     # 1) inverse rotation about Z axis by Omega -> x2, y2, z2
     if Omega is not None:

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -74,12 +74,12 @@ def verify_no_hermitian_pairs(uu, vv, data, test_vis=5, test_channel=0):
     storage space). This routine attempts to determine if the dataset contains 
     Hermitian pairs or not by choosing one data point at a time and then searching the 
     dataset to see if its Hermitian pair exists. The routine will declare that a dataset
-      contains Hermitian pairs or not after it has searched ``test_vis`` number of data 
-      points. If 0 Hermitian pairs have been found for all ``test_vis`` points, then 
-      the dataset will be declared to have no Hermitian pairs. If ``test_vis`` Hermitian
-        pairs were found for ``test_vis`` points searched, then the dataset will be 
-        declared to have Hermitian pairs. If more than 0 but fewer than ``test_vis`` 
-        Hermitian pairs were found for ``test_vis`` points, an error will be raised.
+    contains Hermitian pairs or not after it has searched ``test_vis`` number of data 
+    points. If 0 Hermitian pairs have been found for all ``test_vis`` points, then 
+    the dataset will be declared to have no Hermitian pairs. If ``test_vis`` Hermitian
+    pairs were found for ``test_vis`` points searched, then the dataset will be 
+    declared to have Hermitian pairs. If more than 0 but fewer than ``test_vis`` 
+    Hermitian pairs were found for ``test_vis`` points, an error will be raised.
 
     Gridding objects like :class:`mpol.gridding.DirtyImager` will naturally augment an 
     input dataset to include the Hermitian pairs, so that images of :math:`I_\nu` 
@@ -178,8 +178,8 @@ class GridderBase:
     ``npix`` arguments) to define a corresponding Fourier plane grid as a 
     :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in 
     lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied
-      at once. For more details on the properties of the grid that is created, see the 
-      :class:`.GridCoords` documentation.
+    at once. For more details on the properties of the grid that is created, see the 
+    :class:`.GridCoords` documentation.
 
     Subclasses will accept "loose" *ungridded* visibility data and store the arrays to 
     the object as instance attributes. The input visibility data should be the set of 
@@ -508,16 +508,16 @@ class DataAverager(GridderBase):
     ``npix`` arguments) to define a corresponding Fourier plane grid as a 
     :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in 
     lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied
-      at once. For more details on the properties of the grid that is created, see the 
-      :class:`.GridCoords` documentation.
+    at once. For more details on the properties of the grid that is created, see the 
+    :class:`.GridCoords` documentation.
 
     The :class:`.DataAverager` object accepts "loose" *ungridded* visibility data and 
     stores the arrays to the object as instance attributes. The input visibility data 
     should be the set of visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` 
     domain, and should not contain Hermitian pairs (an error will be raised, if they are
-      encountered). (Note that, unlike :class:`~mpol.gridding.DirtyImager`, this class 
-      *will not* augment the dataset to include Hermitian pairs. This is by design, 
-      since Hermitian pairs should not be used in likelihood calculations).
+    encountered). (Note that, unlike :class:`~mpol.gridding.DirtyImager`, this class 
+    *will not* augment the dataset to include Hermitian pairs. This is by design, 
+    since Hermitian pairs should not be used in likelihood calculations).
 
     The input visibilities can be 1d for a single continuum channel, or 2d for image 
     cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. 

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -1,4 +1,5 @@
-r"""The ``gridding`` module provides two core classes in :class:`mpol.gridding.DataAverager` and :class:`mpol.gridding.DirtyImager`."""
+r"""The ``gridding`` module provides two core classes in 
+:class:`mpol.gridding.DataAverager` and :class:`mpol.gridding.DirtyImager`."""
 
 
 from __future__ import annotations
@@ -16,11 +17,13 @@ from .datasets import GriddedDataset
 
 def _check_data_inputs_2d(uu=None, vv=None, weight=None, data_re=None, data_im=None):
     """
-    Check that all data inputs are the same shape, the weights are positive, and the data_re and data_im are floats.
+    Check that all data inputs are the same shape, the weights are positive, and the 
+    data_re and data_im are floats.
 
     Make a reasonable effort to ensure that Hermitian pairs are *not* included.
 
-    If the user supplied 1d vectors of shape ``(nvis,)``, make them all 2d with one channel, ``(1,nvis)``.
+    If the user supplied 1d vectors of shape ``(nvis,)``, make them all 2d with one 
+    channel, ``(1,nvis)``.
 
     """
 
@@ -58,19 +61,35 @@ def _check_data_inputs_2d(uu=None, vv=None, weight=None, data_re=None, data_im=N
 
 def verify_no_hermitian_pairs(uu, vv, data, test_vis=5, test_channel=0):
     r"""
-    Check that the dataset does not contain Hermitian pairs. Because the sky brightness :math:`I_\nu` is real, the visibility function :math:`\mathcal{V}` is Hermitian, meaning that
+    Check that the dataset does not contain Hermitian pairs. Because the sky brightness 
+    :math:`I_\nu` is real, the visibility function :math:`\mathcal{V}` is Hermitian, 
+    meaning that
 
     .. math::
 
         \mathcal{V}(u, v) = \mathcal{V}^*(-u, -v).
 
-    Most datasets (e.g., those extracted from CASA) will only record one visibility measurement per baseline and not include the duplicate Hermitian pair (to save storage space). This routine attempts to determine if the dataset contains Hermitian pairs or not by choosing one data point at a time and then searching the dataset to see if its Hermitian pair exists. The routine will declare that a dataset contains Hermitian pairs or not after it has searched ``test_vis`` number of data points. If 0 Hermitian pairs have been found for all ``test_vis`` points, then the dataset will be declared to have no Hermitian pairs. If ``test_vis`` Hermitian pairs were found for ``test_vis`` points searched, then the dataset will be declared to have Hermitian pairs. If more than 0 but fewer than ``test_vis`` Hermitian pairs were found for ``test_vis`` points, an error will be raised.
+    Most datasets (e.g., those extracted from CASA) will only record one visibility 
+    measurement per baseline and not include the duplicate Hermitian pair (to save 
+    storage space). This routine attempts to determine if the dataset contains 
+    Hermitian pairs or not by choosing one data point at a time and then searching the 
+    dataset to see if its Hermitian pair exists. The routine will declare that a dataset
+      contains Hermitian pairs or not after it has searched ``test_vis`` number of data 
+      points. If 0 Hermitian pairs have been found for all ``test_vis`` points, then 
+      the dataset will be declared to have no Hermitian pairs. If ``test_vis`` Hermitian
+        pairs were found for ``test_vis`` points searched, then the dataset will be 
+        declared to have Hermitian pairs. If more than 0 but fewer than ``test_vis`` 
+        Hermitian pairs were found for ``test_vis`` points, an error will be raised.
 
-    Gridding objects like :class:`mpol.gridding.DirtyImager` will naturally augment an input dataset to include the Hermitian pairs, so that images of :math:`I_\nu` produced with the inverse Fourier transform turn out to be real.
+    Gridding objects like :class:`mpol.gridding.DirtyImager` will naturally augment an 
+    input dataset to include the Hermitian pairs, so that images of :math:`I_\nu` 
+    produced with the inverse Fourier transform turn out to be real.
 
     Args:
-        uu (numpy array): array of u spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): array of v spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
+        uu (numpy array): array of u spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        vv (numpy array): array of v spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
         data (numpy complex): array of data values
         test_vis (int): the number of data points to search for Hermitian 'matches'
         test_channel (int): the index of the channel to perform the check
@@ -90,10 +109,12 @@ def verify_no_hermitian_pairs(uu, vv, data, test_vis=5, test_channel=0):
     vv = vv[test_channel]
     data = data[test_channel]
 
-    # if the dataset contains Hermitian pairs, then there will be a large number of visibilities that have matching
+    # if the dataset contains Hermitian pairs, 
+    # then there will be a large number of visibilities that have matching
     # (uu, vv) and conjugate data values
 
-    # We don't know what order uu or vv might have been augmented in, or sorted after the fact, so we can't
+    # We don't know what order uu or vv might have been augmented in, or sorted 
+    # after the fact, so we can't
     # rely on quick differencing operations
 
     num_pairs = 0
@@ -128,17 +149,20 @@ def verify_no_hermitian_pairs(uu, vv, data, test_vis=5, test_channel=0):
 
     if num_pairs == test_vis:
         raise DataError(
-            "Hermitian pairs were found in the data. Please provide data without Hermitian pairs."
+            "Hermitian pairs were found in the data. Please provide data without"
+            " Hermitian pairs."
         )
     else:
         raise DataError(
-            f"{num_pairs} Hermitian pairs were found out of {test_vis} visibilities tested, dataset is inconsistent."
+            f"{num_pairs} Hermitian pairs were found out of {test_vis} visibilities"
+            " tested, dataset is inconsistent."
         )
 
     # choose a uu, vv point, then see if the opposite value exists in the dataset
     # if it does, then check that its visibility value is the complex conjugate
 
-    # we could have a max threshold, i.e., like at least 5 need to exist to say the dataset has pairs
+    # we could have a max threshold, i.e., like at least 5 need to exist to say 
+    # the dataset has pairs
 
     # Subtract
     return False
@@ -150,17 +174,37 @@ class GridderBase:
 
     Subclasses will need to implement a `_grid_visibilities(self,...)` method.
 
-    The GridderBase object uses desired image dimensions (via the ``cell_size`` and ``npix`` arguments) to define a corresponding Fourier plane grid as a :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied at once. For more details on the properties of the grid that is created, see the :class:`.GridCoords` documentation.
+    The GridderBase object uses desired image dimensions (via the ``cell_size`` and 
+    ``npix`` arguments) to define a corresponding Fourier plane grid as a 
+    :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in 
+    lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied
+      at once. For more details on the properties of the grid that is created, see the 
+      :class:`.GridCoords` documentation.
 
-    Subclasses will accept "loose" *ungridded* visibility data and store the arrays to the object as instance attributes. The input visibility data should be the set of visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` domain, and should not contain Hermitian pairs (an error will be raised, if they are encountered).  The visibilities can be 1d for a single continuum channel, or 2d for an image cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. Like the :class:`~mpol.images.ImageCube` class, after construction, GridderBase assumes that you are operating with a multi-channel set of visibilities. These routines will still work with single-channel 'continuum' visibilities, they will just have nchan = 1 in the first dimension of most products.
+    Subclasses will accept "loose" *ungridded* visibility data and store the arrays to 
+    the object as instance attributes. The input visibility data should be the set of 
+    visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` domain, and should not 
+    contain Hermitian pairs (an error will be raised, if they are encountered).  The 
+    visibilities can be 1d for a single continuum channel, or 2d for an image cube. If 
+    1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. Like the 
+    :class:`~mpol.images.ImageCube` class, after construction, GridderBase assumes that 
+    you are operating with a multi-channel set of visibilities. These routines will 
+    still work with single-channel 'continuum' visibilities, they will just have 
+    `nchan = 1` in the first dimension of most products.
 
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        weight (2d numpy array): (nchan, nvis) array of thermal weights. Units of [:math:`1/\mathrm{Jy}^2`]
-        data_re (2d numpy array): (nchan, nvis) array of the real part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
-        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        weight (2d numpy array): (nchan, nvis) array of thermal weights. 
+            Units of [:math:`1/\mathrm{Jy}^2`]
+        data_re (2d numpy array): (nchan, nvis) array of the real part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
+        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
 
     """
 
@@ -225,25 +269,35 @@ class GridderBase:
 
     def _sum_cell_values_channel(self, uu, vv, values=None):
         r"""
-        Given a list of loose visibility points :math:`(u,v)` and their corresponding values :math:`x`,
-        partition the points up into 2D :math:`u-v` cells defined by the ``coords`` object attached to
-        the gridder, such that ``cell[i,j]`` has bounds between ``coords.u_edges[j, j+1]`` and ``coords.v_edges[i, i+1]``.
-        Then, sum the corresponding values for each :math:`(u,v)` point that falls within each cell. The resulting
-        cell value is
+        Given a list of loose visibility points :math:`(u,v)` and their corresponding 
+        values :math:`x`, partition the points up into 2D :math:`u-v` cells defined by 
+        the ``coords`` object attached to the gridder, such that ``cell[i,j]`` has 
+        bounds between ``coords.u_edges[j, j+1]`` and ``coords.v_edges[i, i+1]``.
+        Then, sum the corresponding values for each :math:`(u,v)` point that falls 
+        within each cell. The resulting cell value is
 
         .. math::
 
             \mathrm{result}_{i,j} = \sum_k \mathrm{values}_k
 
-        where :math:`k` indexes all :math:`(u,v)` points that fall within ``coords.u_edges[j, j+1]`` and ``coords.v_edges[i, i+1]``. In the case that all values are :math:`1`, the result is the number of visibilities within each cell (i.e., a histogram).
+        where :math:`k` indexes all :math:`(u,v)` points that fall within 
+        ``coords.u_edges[j, j+1]`` and ``coords.v_edges[i, i+1]``. In the case that all 
+        values are :math:`1`, the result is the number of visibilities within each cell 
+        (i.e., a histogram).
 
         Args:
-            uu (np.array): 1D array of East-West spatial frequency coordinates for a specific channel. Units of [:math:`\mathrm{k}\lambda`]
-            vv (np.array): 1D array of North-South spatial frequency coordinates for a specific channel. Units of [:math:`\mathrm{k}\lambda`]
-            values (np.array): 1D array of values (the same length as uu and vv) to use in the sum over each cell. The default (``values=None``) corresponds to using ``values=np.ones_like(uu)`` such that the routine is equivalent to a histogram.
+            uu (np.array): 1D array of East-West spatial frequency coordinates for a 
+                specific channel. Units of [:math:`\mathrm{k}\lambda`]
+            vv (np.array): 1D array of North-South spatial frequency coordinates for a 
+                specific channel. Units of [:math:`\mathrm{k}\lambda`]
+            values (np.array): 1D array of values (the same length as uu and vv) to use 
+                in the sum over each cell. The default (``values=None``) corresponds to 
+                using ``values=np.ones_like(uu)`` such that the routine is equivalent 
+                to a histogram.
 
         Returns:
-            A 2D array of size ``(npix, npix)`` in ground format containing the summed cell quantities.
+            A 2D array of size ``(npix, npix)`` in ground format containing the summed 
+            cell quantities.
         """
 
         result = fast_hist.histogram2d(
@@ -262,14 +316,18 @@ class GridderBase:
 
     def _sum_cell_values_cube(self, values=None):
         r"""
-        Perform the :func:`~mpol.gridding.DataAverager.sum_cell_values_channel` routine over all channels of the
-        input visibilities.
+        Perform the :func:`~mpol.gridding.DataAverager.sum_cell_values_channel` routine 
+        over all channels of the input visibilities.
 
         Args:
-            values (iterable): ``(nchan, nvis)`` array of values to use in the sum over each cell. The default (``values=None``) corresponds to using ``values=np.ones_like(uu)`` such that the routine is equivalent to a histogram.
+            values (iterable): ``(nchan, nvis)`` array of values to use in the sum over 
+                each cell. The default (``values=None``) corresponds to using 
+                ``values=np.ones_like(uu)`` such that the routine is equivalent to a 
+                histogram.
 
         Returns:
-            A 3D array of size ``(nchan, npix, npix)`` in ground format containing the summed cell quantities.
+            A 3D array of size ``(nchan, npix, npix)`` in ground format containing the 
+            summed cell quantities.
 
         """
         # calculate the histogrammed result for all channels
@@ -289,13 +347,16 @@ class GridderBase:
 
     def _extract_gridded_values_to_loose(self, gridded_quantity):
         r"""
-        Extract the gridded cell quantity corresponding to each of the loose visibilities.
+        Extract the gridded cell quantity corresponding to each of the loose 
+        visibilities.
 
         Args:
-            A 3D array of size ``(nchan, npix, npix)`` in ground format containing the gridded cell quantities.
+            A 3D array of size ``(nchan, npix, npix)`` in ground format containing the 
+            gridded cell quantities.
 
         Returns:
-            A ``(nchan, nvis)`` array of values corresponding to the loose visibilities, using the quantity in that cell.
+            A ``(nchan, nvis)`` array of values corresponding to the loose visibilities,
+            using the quantity in that cell.
         """
 
         return np.array(
@@ -307,11 +368,20 @@ class GridderBase:
 
     def _estimate_cell_standard_deviation(self):
         r"""
-        Estimate the `standard deviation <https://en.wikipedia.org/wiki/Standard_deviation>`__ of the real and imaginary visibility values within each :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords`` using the following steps.
+        Estimate the `standard deviation 
+        <https://en.wikipedia.org/wiki/Standard_deviation>`__ of the real and imaginary 
+        visibility values within each :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) 
+        defined by ``self.coords`` using the following steps.
 
-        1. Calculate the mean real :math:`\mu_\Re` and imaginary :math:`\mu_\Im` values within each cell using a weighted mean, assuming that the visibility function is constant across the cell.
-        2. For each visibility :math:`k` that falls within the cell, calculate the real and imaginary residuals (:math:`r_\Re` and :math:`r_\Im`) in units of :math:`\sigma_k`, where :math:`\sigma_k = \sqrt{1/w_k}` and :math:`w_k` is the weight of that visibility.
-        3. Calculate the standard deviation :math:`s_{i,j}` of the residual distributions within each cell
+        1. Calculate the mean real :math:`\mu_\Re` and imaginary :math:`\mu_\Im` values 
+        within each cell using a weighted mean, assuming that the visibility function is
+        constant across the cell.
+        2. For each visibility :math:`k` that falls within the cell, calculate the real 
+        and imaginary residuals (:math:`r_\Re` and :math:`r_\Im`) in units of 
+        :math:`\sigma_k`, where :math:`\sigma_k = \sqrt{1/w_k}` and :math:`w_k` is the 
+        weight of that visibility.
+        3. Calculate the standard deviation :math:`s_{i,j}` of the residual 
+        distributions within each cell
 
         .. math::
 
@@ -325,19 +395,25 @@ class GridderBase:
 
 
         Returns:
-            std_real, std_imag: two 3D arrays of size ``(nchan, npix, npix)`` in ground format containing the standard deviation of the real and imaginary values within each cell, in units of :math:`\sigma`. If everything is correctly calibrated, we expect :math:`s_{i,j} \approx 1 \forall i,j`.
+            std_real, std_imag: two 3D arrays of size ``(nchan, npix, npix)`` in ground 
+            format containing the standard deviation of the real and imaginary values 
+            within each cell, in units of :math:`\sigma`. If everything is correctly 
+            calibrated, we expect :math:`s_{i,j} \approx 1 \forall i,j`.
 
         """
 
-        # 1. use the gridding routine to calculate the mean real and imaginary values on the grid
+        # 1. use the gridding routine to calculate the mean real and imaginary 
+        # values on the grid
         self._grid_visibilities()
 
         # convert grid back to ground format
         mu_re_gridded = np.fft.fftshift(self.data_re_gridded, axes=(1, 2))
         mu_im_gridded = np.fft.fftshift(self.data_im_gridded, axes=(1, 2))
 
-        # extract the real and imaginary values corresponding to the "loose" visibilities
-        # mu_re_gridded and mu_im_gridded are arrays with shape (nchan, ncell_v, ncell_u)
+        # extract the real and imaginary values corresponding to the 
+        # "loose" visibilities
+        # mu_re_gridded and mu_im_gridded are arrays with 
+        # shape (nchan, ncell_v, ncell_u)
         # self.index_v, self.index_u are (nchan, nvis)
         # we want mu_re and mu_im to be (nchan, nvis)
         mu_re = self._extract_gridded_values_to_loose(mu_re_gridded)
@@ -380,13 +456,21 @@ class GridderBase:
 
     def _check_scatter_error(self, max_scatter=1.2):
         """
-        Checks/compares visibility scatter to a given threshold value ``max_scatter`` and raises an AssertionError if the median scatter across all cells exceeds ``max_scatter``.
+        Checks/compares visibility scatter to a given threshold value ``max_scatter`` 
+        and raises an AssertionError if the median scatter across all cells exceeds 
+        ``max_scatter``.
 
         Args:
-            max_scatter (float): the maximum permissible scatter in units of standard deviation.
+            max_scatter (float): the maximum permissible scatter in units of standard 
+            deviation.
 
         Returns:
-            a dictionary containing keys ``return_status``, ``median_re``, and ``median_im``. ``return_status`` is a boolean that is ``False`` if scatter is within acceptable limits of max_scatter (good), and is ``True`` if scatter exceeds acceptable limits. ``median_re`` and ``median_im`` are the median scatter values returned across all cells, in units of standard deviation (estimated from the provided weights).
+            a dictionary containing keys ``return_status``, ``median_re``, and 
+            ``median_im``. ``return_status`` is a boolean that is ``False`` if scatter 
+            is within acceptable limits of max_scatter (good), and is ``True`` if 
+            scatter exceeds acceptable limits. ``median_re`` and ``median_im`` are the 
+            median scatter values returned across all cells, in units of standard 
+            deviation (estimated from the provided weights).
 
         """
         s_re, s_im = self._estimate_cell_standard_deviation()
@@ -411,7 +495,8 @@ class GridderBase:
         The visibility FFT cube fftshifted for plotting with ``imshow``.
 
         Returns:
-            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the image cube, in sky plane format.
+            (torch.complex tensor, of shape ``(nchan, npix, npix)``): the FFT of the 
+            image cube, in sky plane format.
         """
 
         return np.fft.fftshift(self.vis_gridded, axes=(1, 2))
@@ -419,13 +504,31 @@ class GridderBase:
 
 class DataAverager(GridderBase):
     r"""
-    The DataAverager object uses desired image dimensions (via the ``cell_size`` and ``npix`` arguments) to define a corresponding Fourier plane grid as a :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied at once. For more details on the properties of the grid that is created, see the :class:`.GridCoords` documentation.
+    The DataAverager object uses desired image dimensions (via the ``cell_size`` and 
+    ``npix`` arguments) to define a corresponding Fourier plane grid as a 
+    :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in 
+    lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied
+      at once. For more details on the properties of the grid that is created, see the 
+      :class:`.GridCoords` documentation.
 
-    The :class:`.DataAverager` object accepts "loose" *ungridded* visibility data and stores the arrays to the object as instance attributes. The input visibility data should be the set of visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` domain, and should not contain Hermitian pairs (an error will be raised, if they are encountered). (Note that, unlike :class:`~mpol.gridding.DirtyImager`, this class *will not* augment the dataset to include Hermitian pairs. This is by design, since Hermitian pairs should not be used in likelihood calculations).
+    The :class:`.DataAverager` object accepts "loose" *ungridded* visibility data and 
+    stores the arrays to the object as instance attributes. The input visibility data 
+    should be the set of visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` 
+    domain, and should not contain Hermitian pairs (an error will be raised, if they are
+      encountered). (Note that, unlike :class:`~mpol.gridding.DirtyImager`, this class 
+      *will not* augment the dataset to include Hermitian pairs. This is by design, 
+      since Hermitian pairs should not be used in likelihood calculations).
 
-    The input visibilities can be 1d for a single continuum channel, or 2d for image cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. Like the :class:`~mpol.images.ImageCube` class, after construction, the DataAverager assumes that you are operating with a multi-channel set of visibilities. These routines will still work with single-channel 'continuum' visibilities, they will just have nchan = 1 in the first dimension of most products.
+    The input visibilities can be 1d for a single continuum channel, or 2d for image 
+    cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. 
+    Like the :class:`~mpol.images.ImageCube` class, after construction, the DataAverager
+    assumes that you are operating with a multi-channel set of visibilities. These 
+    routines will still work with single-channel 'continuum' visibilities, they will 
+    just have nchan = 1 in the first dimension of most products.
 
-    Once the DataAverager object is initialized with loose visibilities, you can average them and export them for use in Regularized Maximum Likelihood imaging with the :func:`mpol.gridding.DataAverager.to_pytorch_dataset` routine.
+    Once the DataAverager object is initialized with loose visibilities, you can average
+    them and export them for use in Regularized Maximum Likelihood imaging with the 
+    :func:`mpol.gridding.DataAverager.to_pytorch_dataset` routine.
 
     Example::
 
@@ -442,12 +545,18 @@ class DataAverager(GridderBase):
 
 
     Args:
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        weight (2d numpy array): (nchan, nvis) array of thermal weights. Units of [:math:`1/\mathrm{Jy}^2`]
-        data_re (2d numpy array): (nchan, nvis) array of the real part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
-        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        weight (2d numpy array): (nchan, nvis) array of thermal weights. 
+            Units of [:math:`1/\mathrm{Jy}^2`]
+        data_re (2d numpy array): (nchan, nvis) array of the real part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
+        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
 
     """
 
@@ -489,9 +598,9 @@ class DataAverager(GridderBase):
 
     def _grid_weights(self):
         r"""
-        Average the visibility weights to the Fourier grid contained in ``self.coords``, such that
-        the ``self.weight_gridded`` corresponds to the equivalent weight on the averaged visibilities
-        within that cell.
+        Average the visibility weights to the Fourier grid contained in ``self.coords``,
+        such that the ``self.weight_gridded`` corresponds to the equivalent weight on 
+        the averaged visibilities within that cell.
         """
 
         # create the cells as edges around the existing points
@@ -507,8 +616,14 @@ class DataAverager(GridderBase):
         Export gridded visibilities to a PyTorch dataset object.
 
         Args:
-            check_visibility_scatter (bool): whether the routine should check the standard deviation of visibilities in each within each :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Default is ``True``. A ``RuntimeError`` will be raised if any cell has a scatter larger than ``max_scatter``.
-            max_scatter (float): the maximum allowable standard deviation of visibility values in a given :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Defaults to a factor of 120%.
+            check_visibility_scatter (bool): whether the routine should check the 
+                standard deviation of visibilities in each within each :math:`u,v` cell 
+                (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Default 
+                is ``True``. A ``RuntimeError`` will be raised if any cell has a 
+                scatter larger than ``max_scatter``.
+            max_scatter (float): the maximum allowable standard deviation of visibility 
+                values in a given :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) 
+                defined by ``self.coords``. Defaults to a factor of 120%.
 
         Returns:
             :class:`~mpol.datasets.GriddedDataset` with gridded visibilities.
@@ -519,9 +634,11 @@ class DataAverager(GridderBase):
             d = self._check_scatter_error(max_scatter)
             if d["return_status"]:
                 raise RuntimeError(
-                    "Visibility scatter exceeds ``max_scatter``:{:}, indicating a potential problem with data weights. Consider inspecting weights using CASA tools before exporting visibilities for use with MPoL. Median real scatter: {:} x sigma. Median imag scatter: {:} x sigma.".format(
-                        max_scatter, d["median_re"], d["median_im"]
-                    )
+                    "Visibility scatter exceeds ``max_scatter``:{:}, indicating a"
+                    " potential problem with data weights. Consider inspecting weights"
+                    " using CASA tools before exporting visibilities for use with MPoL."
+                    " Median real scatter: {:} x sigma. Median imag scatter: {:} x"
+                    " sigma.".format(max_scatter, d["median_re"], d["median_im"])
                 )
 
         # grid visibilities (uniform weighting necessary here) and weights
@@ -539,13 +656,28 @@ class DataAverager(GridderBase):
 
 class DirtyImager(GridderBase):
     r"""
-    This class is mainly used for producing diagnostic "dirty" images of the visibility data.
+    This class is mainly used for producing diagnostic "dirty" images of the 
+    visibility data.
 
-    The DirtyImager object uses desired image dimensions (via the ``cell_size`` and ``npix`` arguments) to define a corresponding Fourier plane grid as a :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied at once. For more details on the properties of the grid that is created, see the :class:`.GridCoords` documentation.
+    The DirtyImager object uses desired image dimensions (via the ``cell_size`` and 
+    ``npix`` arguments) to define a corresponding Fourier plane grid as a 
+    :class:`.GridCoords` object. A pre-computed :class:`.GridCoords` can be supplied in 
+    lieu of ``cell_size`` and ``npix``, but all three arguments should never be supplied
+    at once. For more details on the properties of the grid that is created, see the 
+    :class:`.GridCoords` documentation.
 
-    The :class:`.DirtyImager` object accepts "loose" *ungridded* visibility data and stores the arrays to the object as instance attributes. The input visibility data should be the normal set of visibilities over the full :math:`[-u,u]` and :math:`[-v,v]` domain; internally the DirtyImager will automatically augment the dataset to include the complex conjugates, i.e. the 'Hermitian pairs.'
+    The :class:`.DirtyImager` object accepts "loose" *ungridded* visibility data and 
+    stores the arrays to the object as instance attributes. The input visibility data 
+    should be the normal set of visibilities over the full :math:`[-u,u]` and 
+    :math:`[-v,v]` domain; internally the DirtyImager will automatically augment the 
+    dataset to include the complex conjugates, i.e. the 'Hermitian pairs.'
 
-    The input visibilities can be 1d for a single continuum channel, or 2d for image cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. Like the :class:`~mpol.images.ImageCube` class, after construction, the DirtyImager assumes that you are operating with a multi-channel set of visibilities. These routines will still work with single-channel 'continuum' visibilities, they will just have nchan = 1 in the first dimension of most products.
+    The input visibilities can be 1d for a single continuum channel, or 2d for image 
+    cube. If 1d, visibilities will be converted to 2d arrays of shape ``(1, nvis)``. 
+    Like the :class:`~mpol.images.ImageCube` class, after construction, the DirtyImager 
+    assumes that you are operating with a multi-channel set of visibilities. These 
+    routines will still work with single-channel 'continuum' visibilities, they will 
+    just have nchan = 1 in the first dimension of most products.
 
     Example::
 
@@ -564,14 +696,18 @@ class DirtyImager(GridderBase):
     Args:
         cell_size (float): width of a single square pixel in [arcsec]
         npix (int): number of pixels in the width of the image
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
-        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. Units of [:math:`\mathrm{k}\lambda`]
-        weight (2d numpy array): (nchan, nvis) array of thermal weights. Units of [:math:`1/\mathrm{Jy}^2`]
-        data_re (2d numpy array): (nchan, nvis) array of the real part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
-        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the visibility measurements. Units of [:math:`\mathrm{Jy}`]
-
-
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
+        uu (numpy array): (nchan, nvis) array of u spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        vv (numpy array): (nchan, nvis) array of v spatial frequency coordinates. 
+            Units of [:math:`\mathrm{k}\lambda`]
+        weight (2d numpy array): (nchan, nvis) array of thermal weights. 
+            Units of [:math:`1/\mathrm{Jy}^2`]
+        data_re (2d numpy array): (nchan, nvis) array of the real part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
+        data_im (2d numpy array): (nchan, nvis) array of the imaginary part of the 
+            visibility measurements. Units of [:math:`\mathrm{Jy}`]
 
     """
 
@@ -597,7 +733,7 @@ class DirtyImager(GridderBase):
         # make sure we still fit into the grid
         self.coords.check_data_fit(uu, vv)
 
-        # initialize base objects 
+        # initialize base objects
         # Hermitian conjugates taken care of by @property below
         self.uu_base = uu
         self.vv_base = vv
@@ -641,9 +777,18 @@ class DirtyImager(GridderBase):
         Grid the loose data visibilities to the Fourier grid in preparation for imaging.
 
         Args:
-            weighting (string): The type of cell averaging to perform. Choices of ``"natural"``, ``"uniform"``, or ``"briggs"``, following CASA tclean. If ``"briggs"``, also specify a robust value.
-            robust (float): If ``weighting='briggs'``, specify a robust value in the range [-2, 2]. ``robust=-2`` approximately corresponds to uniform weighting and ``robust=2`` approximately corresponds to natural weighting.
-            taper_function (function reference): a function assumed to be of the form :math:`f(u,v)` which calculates a prefactor in the range :math:`[0,1]` and premultiplies the visibility data. The function must assume that :math:`u` and :math:`v` will be supplied in units of :math:`\mathrm{k}\lambda`. By default no taper is applied.
+            weighting (string): The type of cell averaging to perform. Choices of 
+                ``"natural"``, ``"uniform"``, or ``"briggs"``, following CASA tclean. 
+                If ``"briggs"``, also specify a robust value.
+            robust (float): If ``weighting='briggs'``, specify a robust value in the 
+                range [-2, 2]. ``robust=-2`` approximately corresponds to uniform 
+                weighting and ``robust=2`` approximately corresponds to natural 
+                weighting.
+            taper_function (function reference): a function assumed to be of the form 
+                :math:`f(u,v)` which calculates a prefactor in the range :math:`[0,1]` 
+                and premultiplies the visibility data. The function must assume that 
+                :math:`u` and :math:`v` will be supplied in units of 
+                :math:`\mathrm{k}\lambda`. By default no taper is applied.
         """
 
         if taper_function is None:
@@ -672,7 +817,8 @@ class DirtyImager(GridderBase):
         elif weighting == "briggs":
             if robust is None or not -2 <= robust <= 2:
                 raise ValueError(
-                    "With 'briggs' weighting, a robust value must be specified between [-2, 2]."
+                    "With 'briggs' weighting, a robust value must be specified between"
+                    " [-2, 2]."
                 )
 
             # implement robust weighting using the definition used in CASA
@@ -695,7 +841,8 @@ class DirtyImager(GridderBase):
 
         else:
             raise ValueError(
-                "weighting must be specified as one of 'natural', 'uniform', or 'briggs'"
+                "weighting must be specified as one of 'natural', 'uniform', or"
+                " 'briggs'"
             )
 
         # the factor of 2 in the denominator is needed because
@@ -733,15 +880,17 @@ class DirtyImager(GridderBase):
 
         Args:
             C (1D np.array): normalization constants for each channel
-            re_gridded_beam (3d np.array): the gridded visibilities corresponding to a unit point source in the center of the field.
+            re_gridded_beam (3d np.array): the gridded visibilities corresponding to a 
+                unit point source in the center of the field.
 
         Returns:
-            numpy image cube with a dirty beam (PSF) for each channel. By definition, the peak is normalized to 1.0.
+            numpy image cube with a dirty beam (PSF) for each channel. By definition, 
+            the peak is normalized to 1.0.
         """
         # if we're sticking to the dirty beam and image equations in Briggs' Ph.D. thesis,
         # no correction for du or dv prefactors needed here
-        # that is because we are using the FFT to compute an already discretized equation, not
-        # approximating a continuous equation.
+        # that is because we are using the FFT to compute an already discretized 
+        # equation, not approximating a continuous equation.
 
         beam = self._fliplr_cube(
             np.fft.fftshift(
@@ -755,7 +904,8 @@ class DirtyImager(GridderBase):
 
         if np.max(beam.imag) >= 1e-10:
             raise ThresholdExceededError(
-                "Dirty beam contained substantial imaginary values, check input visibilities, otherwise raise a github issue."
+                "Dirty beam contained substantial imaginary values, check input"
+                " visibilities, otherwise raise a github issue."
             )
 
         self.beam = beam.real
@@ -763,13 +913,19 @@ class DirtyImager(GridderBase):
         return self.beam
 
     def _null_dirty_beam(self, ntheta=24, single_channel_estimate=True):
-        r"""Zero out (null) all pixels in the dirty beam exterior to the first null, for each channel.
+        r"""Zero out (null) all pixels in the dirty beam exterior to the first null, 
+        for each channel.
 
         Args:
-            ntheta (int): number of azimuthal wedges to use for the 1st null calculation. More wedges will result in a more accurate estimate of dirty beam area, but will also take longer.
-            single_channel_estimate (bool): If ``True`` (the default), use the area estimated from the first channel for all channels in the multi-channel image cube. If ``False``, calculate the beam area for all channels.
+            ntheta (int): number of azimuthal wedges to use for the 1st null 
+                calculation. More wedges will result in a more accurate estimate of 
+                dirty beam area, but will also take longer.
+            single_channel_estimate (bool): If ``True`` (the default), use the area 
+                estimated from the first channel for all channels in the multi-channel 
+                image cube. If ``False``, calculate the beam area for all channels.
 
-        Returns: a cube like the dirty beam, but with all pixels exterior to the first null set to 0.
+        Returns: a cube like the dirty beam, but with all pixels exterior to the first 
+            null set to 0.
         """
 
         try:
@@ -779,12 +935,13 @@ class DirtyImager(GridderBase):
 
         # consider the 2D beam for each channel described by polar coordinates r, theta.
         #
-        # this routine works by finding the smallest r for which the beam goes negative (the first null)
-        # as a function of theta. Then, for this same theta, all pixels (negative or not) with values of r larger than
+        # this routine works by finding the smallest r for which the beam goes negative 
+        # (the first null) as a function of theta. Then, for this same theta, all pixels
+        # (negative or not) with values of r larger than
         # this are set to 0.
 
-        # the end product of this routine will be a "nulled" beam, which can be used in the calculation
-        # of dirty beam area.
+        # the end product of this routine will be a "nulled" beam, which can be used in 
+        # the calculation of dirty beam area.
 
         # the angular extent for each "slice"
         # the smaller the slice, the more accurate the area estimate, but also the
@@ -799,8 +956,8 @@ class DirtyImager(GridderBase):
 
         nulled_beam = self.beam.copy()
         # for each channel,
-        # find the first occurrence of a non-zero value, such that we end up with a continuous
-        # ring of masked values.
+        # find the first occurrence of a non-zero value, such that we end up with a 
+        # continuous ring of masked values.
         for i in range(self.nchan):
             nb = nulled_beam[i]
             ind_neg = nb < 0
@@ -830,14 +987,26 @@ class DirtyImager(GridderBase):
 
     def get_dirty_beam_area(self, ntheta=24, single_channel_estimate=True):
         r"""
-        Compute the effective area of the dirty beam for each channel. Assumes that the beam has already been generated by running :func:`~mpol.gridding.DirtyImager.get_dirty_image`. This is an approximate calculation involving a simple sum over all pixels out to the first null (zero crossing) of the dirty beam. This quantity is designed to approximate the conversion of image units from :math:`[\mathrm{Jy}\,\mathrm{beam}^{-1}]` to :math:`[\mathrm{Jy}\,\mathrm{arcsec}^{-2}]`, even though units of :math:`[\mathrm{Jy}\,\mathrm{dirty\;beam}^{-1}]` are technically undefined.
+        Compute the effective area of the dirty beam for each channel. Assumes that the 
+        beam has already been generated by running 
+        :func:`~mpol.gridding.DirtyImager.get_dirty_image`. This is an approximate 
+        calculation involving a simple sum over all pixels out to the first null 
+        (zero crossing) of the dirty beam. This quantity is designed to approximate the 
+        conversion of image units from :math:`[\mathrm{Jy}\,\mathrm{beam}^{-1}]` to 
+        :math:`[\mathrm{Jy}\,\mathrm{arcsec}^{-2}]`, even though units of 
+        :math:`[\mathrm{Jy}\,\mathrm{dirty\;beam}^{-1}]` are technically undefined.
 
         Args:
-            ntheta (int): number of azimuthal wedges to use for the 1st null calculation. More wedges will result in a more accurate estimate of dirty beam area, but will also take longer.
-            single_channel_estimate (bool): If ``True`` (the default), use the area estimated from the first channel for all channels in the multi-channel image cube. If ``False``, calculate the beam area for all channels.
+            ntheta (int): number of azimuthal wedges to use for the 1st null 
+                calculation. More wedges will result in a more accurate estimate of 
+                dirty beam area, but will also take longer.
+            single_channel_estimate (bool): If ``True`` (the default), use the area 
+                estimated from the first channel for all channels in the multi-channel 
+                image cube. If ``False``, calculate the beam area for all channels.
 
         Returns:
-            (1D numpy array float) beam area for each channel in units of :math:`[\mathrm{arcsec}^{2}]`
+            (1D numpy array float) beam area for each channel in units of 
+            :math:`[\mathrm{arcsec}^{2}]`
         """
         nulled = self._null_dirty_beam(
             ntheta=ntheta, single_channel_estimate=single_channel_estimate
@@ -858,16 +1027,38 @@ class DirtyImager(GridderBase):
         Calculate the dirty image.
 
         Args:
-            weighting (string): The type of cell averaging to perform. Choices of ``"natural"``, ``"uniform"``, or ``"briggs"``, following CASA tclean. If ``"briggs"``, also specify a robust value.
-            robust (float): If ``weighting='briggs'``, specify a robust value in the range [-2, 2]. ``robust=-2`` approxmately corresponds to uniform weighting and ``robust=2`` approximately corresponds to natural weighting.
-            taper_function (function reference): a function assumed to be of the form :math:`f(u,v)` which calculates a prefactor in the range :math:`[0,1]` and premultiplies the visibility data. The function must assume that :math:`u` and :math:`v` will be supplied in units of :math:`\mathrm{k}\lambda`. By default no taper is applied.
-            unit (string): what unit should the image be in. Default is ``"Jy/beam"``. If ``"Jy/arcsec^2"``, then the effective area of the dirty beam will be used to convert from ``"Jy/beam"`` to ``"Jy/arcsec^2"``.
-            check_visibility_scatter (bool): whether the routine should check the standard deviation of visibilities in each within each :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Default is ``True``. A ``RuntimeWarning`` will be raised if any cell has a scatter larger than ``max_scatter``.
-            max_scatter (float): the maximum allowable standard deviation of visibility values in a given :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Defaults to a factor of 120%.
-            **beam_kwargs: all additional keyword arguments passed to :func:`~mpol.gridding.get_dirty_beam_area` if ``unit="Jy/arcsec^2"``.
+            weighting (string): The type of cell averaging to perform. Choices of 
+                ``"natural"``, ``"uniform"``, or ``"briggs"``, following CASA tclean. 
+                If ``"briggs"``, also specify a robust value.
+            robust (float): If ``weighting='briggs'``, specify a robust value in the 
+                range [-2, 2]. ``robust=-2`` approxmately corresponds to uniform 
+                weighting and ``robust=2`` approximately corresponds to natural 
+                weighting.
+            taper_function (function reference): a function assumed to be of the form 
+                :math:`f(u,v)` which calculates a prefactor in the range :math:`[0,1]` 
+                and premultiplies the visibility data. The function must assume that 
+                :math:`u` and :math:`v` will be supplied in units of 
+                :math:`\mathrm{k}\lambda`. By default no taper is applied.
+            unit (string): what unit should the image be in. 
+                Default is ``"Jy/beam"``. If ``"Jy/arcsec^2"``, then the effective area 
+                of the dirty beam will be used to convert from ``"Jy/beam"`` to 
+                ``"Jy/arcsec^2"``.
+            check_visibility_scatter (bool): whether the routine should check the 
+                standard deviation of visibilities in each within each :math:`u,v` cell 
+                (:math:`\mathrm{cell}_{i,j}`) defined by ``self.coords``. Default is 
+                ``True``. A ``RuntimeWarning`` will be raised if any cell has a scatter 
+                larger than ``max_scatter``.
+            max_scatter (float): the maximum allowable standard deviation of visibility 
+                values in a given :math:`u,v` cell (:math:`\mathrm{cell}_{i,j}`) defined
+                by ``self.coords``. Defaults to a factor of 120%.
+            **beam_kwargs: all additional keyword arguments passed to 
+                :func:`~mpol.gridding.get_dirty_beam_area` if ``unit="Jy/arcsec^2"``.
 
         Returns:
-            2-tuple of (``image``, ``beam``) where ``image`` is an (nchan, npix, npix) numpy array of the dirty image cube in units ``unit``. ``beam`` is an numpy image cube with a dirty beam (PSF) for each channel. The units of the beam are always Jy/{dirty beam}, i.e., the peak of the beam is normalized to 1.0.
+            2-tuple of (``image``, ``beam``) where ``image`` is an (nchan, npix, npix) 
+            numpy array of the dirty image cube in units ``unit``. ``beam`` is an numpy 
+            image cube with a dirty beam (PSF) for each channel. The units of the beam 
+            are always Jy/{dirty beam}, i.e., the peak of the beam is normalized to 1.0.
         """
 
         # check unit input
@@ -880,7 +1071,11 @@ class DirtyImager(GridderBase):
             if d["return_status"]:
                 warnings.warn(
                     RuntimeWarning(
-                        "Visibility scatter exceeds ``max_scatter``:{:}, indicating a potential problem with data weights. Consider inspecting weights using CASA tools before exporting visibilities for use with MPoL. Median real scatter: {:} x sigma. Median imag scatter: {:} x sigma.".format(
+                        "Visibility scatter exceeds ``max_scatter``:{:}, indicating a"
+                        " potential problem with data weights. Consider inspecting"
+                        " weights using CASA tools before exporting visibilities for"
+                        " use with MPoL. Median real scatter: {:} x sigma. Median imag"
+                        " scatter: {:} x sigma.".format(
                             max_scatter, d["median_re"], d["median_im"]
                         )
                     )
@@ -906,9 +1101,10 @@ class DirtyImager(GridderBase):
         # also pre-stores internal self.beam value for area routine, if necessary
         beam = self._get_dirty_beam(self.C, self.re_gridded_beam)
 
-        # for units of Jy/arcsec^2, we could just leave out the C constant *if* we were doing
-        # uniform weighting. The relationships get more complex for robust or natural weighting, however,
-        # so it's safer to calculate the number of arcseconds^2 per beam
+        # for units of Jy/arcsec^2, we could just leave out the C constant *if* we were 
+        # doing uniform weighting. The relationships get more complex for robust or 
+        # natural weighting, however, so it's safer to calculate the number of 
+        # arcseconds^2 per beam
         if unit == "Jy/arcsec^2":
             beam_area_per_chan = self.get_dirty_beam_area(**beam_kwargs)  # [arcsec^2]
 
@@ -920,7 +1116,8 @@ class DirtyImager(GridderBase):
 
         if np.max(img.imag) >= 1e-10:
             raise ThresholdExceededError(
-                "Dirty image contained substantial imaginary values, check input visibilities, otherwise raise a github issue."
+                "Dirty image contained substantial imaginary values, check input"
+                " visibilities, otherwise raise a github issue."
             )
 
         return img.real, beam

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -269,11 +269,11 @@ class ImageCube(nn.Module):
         r"""
         If the ImageCube object was initialized with ``passthrough=True``, the ``cube``
         argument is required. ``forward`` essentially just passes this on as an identity
-          operation.
+        operation.
 
         If the ImageCube object was initialized with ``passthrough=False``, the ``cube``
-          argument is not permitted, and ``forward`` passes on the stored
-          ``nn.Parameter`` cube as an identity operation.
+        argument is not permitted, and ``forward`` passes on the stored
+        ``nn.Parameter`` cube as an identity operation.
 
         Args:
             cube (3D torch tensor of shape ``(nchan, npix, npix)``): only permitted if

--- a/src/mpol/losses.py
+++ b/src/mpol/losses.py
@@ -1,8 +1,8 @@
 r"""The following loss functions are available to use in imaging. Many of the 
-definitions follow those in Appendix A of `EHT-IV 2019 
-<https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, including the 
-regularization strength, which aspires to be similar across all terms, providing at 
-least a starting point for tuning multiple loss functions.
+definitions follow those in Appendix A of 
+`EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, 
+including the regularization strength, which aspires to be similar across all terms, 
+providing at least a starting point for tuning multiple loss functions.
 
 If you don't see a loss function you need, it's easy to write your own directly within 
 your optimization script. If you like it, please consider opening a pull request!
@@ -279,8 +279,8 @@ def TV_channel(cube, epsilon=1e-10):
     Args:
         cube (any 3D tensor): the image cube array :math:`I_{lmv}`
         epsilon (float): a softening parameter in 
-        [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any channel-to-channel pixel 
-        variations greater than this parameter will have a significant penalty.
+            [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any channel-to-channel pixel 
+            variations greater than this parameter will have a significant penalty.
 
     Returns:
         torch.double: total variation loss
@@ -328,8 +328,8 @@ def sparsity(cube, mask=None):
     Args:
         cube (nchan, npix, npix): tensor image cube
         mask (boolean): tensor array the same shape as ``cube``. The sparsity prior 
-        will be applied to those pixels where the mask is ``True``. Default is to apply 
-        prior to all pixels.
+            will be applied to those pixels where the mask is ``True``. Default is 
+            to apply prior to all pixels.
 
     Returns:
         torch.double: sparsity loss calculated where ``mask == True``

--- a/src/mpol/losses.py
+++ b/src/mpol/losses.py
@@ -1,6 +1,11 @@
-r"""The following loss functions are available to use in imaging. Many of the definitions follow those in Appendix A of `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, including the regularization strength, which aspires to be similar across all terms, providing at least a starting point for tuning multiple loss functions.
+r"""The following loss functions are available to use in imaging. Many of the 
+definitions follow those in Appendix A of `EHT-IV 2019 
+<https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, including the 
+regularization strength, which aspires to be similar across all terms, providing at 
+least a starting point for tuning multiple loss functions.
 
-If you don't see a loss function you need, it's easy to write your own directly within your optimization script. If you like it, please consider opening a pull request!
+If you don't see a loss function you need, it's easy to write your own directly within 
+your optimization script. If you like it, please consider opening a pull request!
 """
 
 import numpy as np
@@ -12,16 +17,21 @@ from .constants import *
 
 def chi_squared(model_vis, data_vis, weight):
     r"""
-    Compute the :math:`\chi^2` between the complex data :math:`\boldsymbol{V}` and model :math:`M` visibilities using
+    Compute the :math:`\chi^2` between the complex data :math:`\boldsymbol{V}` and model
+      :math:`M` visibilities using
 
     .. math::
 
         \chi^2(\boldsymbol{V}|\,\boldsymbol{\theta}) = \sum_i^N \frac{|V_i - M(u_i, v_i |\,\boldsymbol{\theta})|^2}{\sigma_i^2}
 
-    where :math:`\sigma_i^2 = 1/w_i`. The sum is over all of the provided visibilities. This function is agnostic as to whether the sum should include the Hermitian conjugate visibilities, but be aware that the answer returned will be different between the two cases. We recommend not including the Hermitian conjugates.
+    where :math:`\sigma_i^2 = 1/w_i`. The sum is over all of the provided visibilities. 
+    This function is agnostic as to whether the sum should include the Hermitian 
+    conjugate visibilities, but be aware that the answer returned will be different 
+    between the two cases. We recommend not including the Hermitian conjugates.
 
     Args:
-        model_vis (PyTorch complex): array tuple of the model representing :math:`\boldsymbol{V}`
+        model_vis (PyTorch complex): array tuple of the model representing 
+            :math:`\boldsymbol{V}`
         data_vis (PyTorch complex): array of the data values representing :math:`M`
         weight (PyTorch real): array of weight values representing :math:`w_i`
 
@@ -38,7 +48,8 @@ def chi_squared(model_vis, data_vis, weight):
 
 def log_likelihood(model_vis, data_vis, weight):
     r"""
-    Compute the log likelihood function :math:`\ln\mathcal{L}` between the complex data :math:`\boldsymbol{V}` and model :math:`M` visibilities using
+    Compute the log likelihood function :math:`\ln\mathcal{L}` between the complex data 
+    :math:`\boldsymbol{V}` and model :math:`M` visibilities using
 
     .. math::
 
@@ -46,10 +57,14 @@ def log_likelihood(model_vis, data_vis, weight):
 
     where :math:`\chi^2` is evaluated using :func:`mpol.losses.chi_squared`.
 
-    This function is agnostic as to whether the sum should include the Hermitian conjugate visibilities, but be aware that the normalization of the answer returned will be different between the two cases. Inference of the parameter values should be unaffected. We recommend not including the Hermitian conjugates.
+    This function is agnostic as to whether the sum should include the Hermitian 
+    conjugate visibilities, but be aware that the normalization of the answer returned 
+    will be different between the two cases. Inference of the parameter values should 
+    be unaffected. We recommend not including the Hermitian conjugates.
 
     Args:
-        model_vis (PyTorch complex): array tuple of the model representing :math:`\boldsymbol{V}`
+        model_vis (PyTorch complex): array tuple of the model representing 
+            :math:`\boldsymbol{V}`
         data_vis (PyTorch complex): array of the data values representing :math:`M`
         weight (PyTorch real): array of weight values representing :math:`w_i`
 
@@ -71,19 +86,34 @@ def log_likelihood(model_vis, data_vis, weight):
 
 def nll(model_vis, data_vis, weight):
     r"""
-    Calculate a normalized "negative log likelihood" loss between the complex data :math:`\boldsymbol{V}` and model :math:`M` visibilities using
+    Calculate a normalized "negative log likelihood" loss between the complex data 
+    :math:`\boldsymbol{V}` and model :math:`M` visibilities using
 
     .. math::
 
         L_\mathrm{nll} = \frac{1}{2 N} \chi^2(\boldsymbol{V}|\,\boldsymbol{\theta})
 
-    where :math:`\chi^2` is evaluated using :func:`mpol.losses.chi_squared`. Visibilities may be any shape as long as all quantities have the same shape. Following `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, we apply
-    a prefactor :math:`1/(2 N)`, where :math:`N` is the number of visibilities. The factor of 2 comes in because we must count real and imaginaries in the :math:`\chi^2` sum. This means that this normalized negative log likelihood loss function will have a minimum value of $L_\mathrm{nll}(\hat{\boldsymbol{\theta}}) \approx 1$ for a well-fit model (regardless of the number of data points), making it easier to set the prefactor strengths of other regularizers *relative* to this value.
+    where :math:`\chi^2` is evaluated using :func:`mpol.losses.chi_squared`. 
+    Visibilities may be any shape as long as all quantities have the same shape. 
+    Following `EHT-IV 2019 
+    <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_, we apply
+    a prefactor :math:`1/(2 N)`, where :math:`N` is the number of visibilities. The 
+    factor of 2 comes in because we must count real and imaginaries in the 
+    :math:`\chi^2` sum. This means that this normalized negative log likelihood loss 
+    function will have a minimum value of $L_\mathrm{nll}(\hat{\boldsymbol{\theta}}) 
+    \approx 1$ for a well-fit model (regardless of the number of data points), making 
+    it easier to set the prefactor strengths of other regularizers *relative* to this 
+    value.
 
-    Note that this function should only be used in an optimization or point estimate situation. If it is used in any situation where uncertainties on parameter values are determined (such as Markov Chain Monte Carlo), it will return the wrong answer. This is because the relative scaling of :math:`L_\mathrm{nll}` with respect to parameter value is incorrect.
+    Note that this function should only be used in an optimization or point estimate 
+    situation. If it is used in any situation where uncertainties on parameter values 
+    are determined (such as Markov Chain Monte Carlo), it will return the wrong answer. 
+    This is because the relative scaling of :math:`L_\mathrm{nll}` with respect to 
+    parameter value is incorrect.
 
     Args:
-        model_vis (PyTorch complex): array tuple of the model representing :math:`\boldsymbol{V}`
+        model_vis (PyTorch complex): array tuple of the model representing 
+            :math:`\boldsymbol{V}`
         data_vis (PyTorch complex): array of the data values representing :math:`M`
         weight (PyTorch real): array of weight values representing :math:`w_i`
 
@@ -99,10 +129,14 @@ def nll(model_vis, data_vis, weight):
 
 def chi_squared_gridded(modelVisibilityCube, griddedDataset):
     r"""
-    Calculate the :math:`\chi^2` (corresponding to :func:`~mpol.losses.chi_squared`) using gridded data and model visibilities.
+    Calculate the :math:`\chi^2` (corresponding to :func:`~mpol.losses.chi_squared`) 
+    using gridded data and model visibilities.
 
     Args:
-        modelVisibilityCube (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
+        modelVisibilityCube (torch complex tensor): torch tensor with shape 
+            ``(nchan, npix, npix)`` to be indexed by the ``mask`` from 
+            :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," 
+            as in output from :meth:`mpol.fourier.FourierCube.forward()`.
         griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
 
     Returns:
@@ -123,10 +157,14 @@ def chi_squared_gridded(modelVisibilityCube, griddedDataset):
 
 def log_likelihood_gridded(modelVisibilityCube, griddedDataset):
     r"""
-    Calculate the log likelihood function :math:`\ln\mathcal{L}` (corresponding to :func:`~mpol.losses.log_likelihood`) using gridded data and model visibilities.
+    Calculate the log likelihood function :math:`\ln\mathcal{L}` (corresponding to 
+    :func:`~mpol.losses.log_likelihood`) using gridded data and model visibilities.
 
     Args:
-        modelVisibilityCube (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
+        modelVisibilityCube (torch complex tensor): torch tensor with shape 
+            ``(nchan, npix, npix)`` to be indexed by the ``mask`` from 
+            :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as 
+            in output from :meth:`mpol.fourier.FourierCube.forward()`.
         griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
 
     Returns:
@@ -146,10 +184,15 @@ def log_likelihood_gridded(modelVisibilityCube, griddedDataset):
 
 def nll_gridded(modelVisibilityCube, griddedDataset):
     r"""
-    Calculate a normalized "negative log likelihood" (corresponding to :func:`~mpol.losses.nll`) using gridded data and model visibilities. Function will return the same value regardless of whether Hermitian pairs are included.
+    Calculate a normalized "negative log likelihood" (corresponding to 
+    :func:`~mpol.losses.nll`) using gridded data and model visibilities. Function will 
+    return the same value regardless of whether Hermitian pairs are included.
 
     Args:
-        vis (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. Assumes tensor is "pre-packed," as in output from :meth:`mpol.fourier.FourierCube.forward()`.
+        vis (torch complex tensor): torch tensor with shape ``(nchan, npix, npix)`` to 
+            be indexed by the ``mask`` from :class:`~mpol.datasets.GriddedDataset`. 
+            Assumes tensor is "pre-packed," as in output from 
+            :meth:`mpol.fourier.FourierCube.forward()`.
         griddedDataset: instantiated :class:`~mpol.datasets.GriddedDataset` object
 
     Returns:
@@ -162,12 +205,16 @@ def nll_gridded(modelVisibilityCube, griddedDataset):
 
 def entropy(cube, prior_intensity, tot_flux=10):
     r"""
-    Calculate the entropy loss of a set of pixels following the definition in `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_.
+    Calculate the entropy loss of a set of pixels following the definition in 
+    `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_.
 
     Args:
-        cube (any tensor): pixel values must be positive :math:`I_i > 0` for all :math:`i`
-        prior_intensity (any tensor): the prior value :math:`p` to calculate entropy against. Could be a single constant or an array the same shape as image.
-        tot_flux (float): a fixed normalization factor; the user-defined target total flux density
+        cube (any tensor): pixel values must be positive :math:`I_i > 0` 
+            for all :math:`i`
+        prior_intensity (any tensor): the prior value :math:`p` to calculate entropy 
+            against. Could be a single constant or an array the same shape as image.
+        tot_flux (float): a fixed normalization factor; the user-defined target total 
+            flux density
 
     Returns:
         torch.double: entropy loss
@@ -188,11 +235,20 @@ def entropy(cube, prior_intensity, tot_flux=10):
 
 def TV_image(sky_cube, epsilon=1e-10):
     r"""
-    Calculate the total variation (TV) loss in the image dimension (R.A. and DEC). Following the definition in `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_ Promotes the image to be piecewise smooth and the gradient of the image to be sparse.
+    Calculate the total variation (TV) loss in the image dimension (R.A. and DEC). 
+    Following the definition in `EHT-IV 2019 
+    <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_ Promotes the 
+    image to be piecewise smooth and the gradient of the image to be sparse.
 
     Args:
-        sky_cube (any 3D tensor): the image cube array :math:`I_{lmv}`, where :math:`l` is R.A. in :math:`ndim=3`, :math:`m` is DEC in :math:`ndim=2`, and :math:`v` is the channel (velocity or frequency) dimension in :math:`ndim=1`. Should be in sky format representation.
-        epsilon (float): a softening parameter in [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any pixel-to-pixel variations within each image slice greater than this parameter will have a significant penalty.
+        sky_cube (any 3D tensor): the image cube array :math:`I_{lmv}`, where :math:`l` 
+            is R.A. in :math:`ndim=3`, :math:`m` is DEC in :math:`ndim=2`, and 
+            :math:`v` is the channel (velocity or frequency) dimension in 
+            :math:`ndim=1`. Should be in sky format representation.
+        epsilon (float): a softening parameter in 
+            [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any pixel-to-pixel variations 
+            within each image slice greater than this parameter will have a 
+            significant penalty.
 
     Returns:
         torch.double: total variation loss
@@ -216,11 +272,15 @@ def TV_image(sky_cube, epsilon=1e-10):
 
 def TV_channel(cube, epsilon=1e-10):
     r"""
-    Calculate the total variation (TV) loss in the channel dimension. Following the definition in `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_.
+    Calculate the total variation (TV) loss in the channel dimension. Following the 
+    definition in `EHT-IV 2019 
+    <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_.
 
     Args:
         cube (any 3D tensor): the image cube array :math:`I_{lmv}`
-        epsilon (float): a softening parameter in [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any channel-to-channel pixel variations greater than this parameter will have a significant penalty.
+        epsilon (float): a softening parameter in 
+        [:math:`\mathrm{Jy}/\mathrm{arcsec}^2`]. Any channel-to-channel pixel 
+        variations greater than this parameter will have a significant penalty.
 
     Returns:
         torch.double: total variation loss
@@ -261,11 +321,15 @@ def edge_clamp(cube):
 
 def sparsity(cube, mask=None):
     r"""
-    Enforce a sparsity prior on the image cube using the :math:`L_1` norm. Optionally provide a boolean mask to apply the prior to only the ``True`` locations. For example, you might want this mask to be ``True`` for background regions.
+    Enforce a sparsity prior on the image cube using the :math:`L_1` norm. Optionally 
+    provide a boolean mask to apply the prior to only the ``True`` locations. For 
+    example, you might want this mask to be ``True`` for background regions.
 
     Args:
         cube (nchan, npix, npix): tensor image cube
-        mask (boolean): tensor array the same shape as ``cube``. The sparsity prior will be applied to those pixels where the mask is ``True``. Default is to apply prior to all pixels.
+        mask (boolean): tensor array the same shape as ``cube``. The sparsity prior 
+        will be applied to those pixels where the mask is ``True``. Default is to apply 
+        prior to all pixels.
 
     Returns:
         torch.double: sparsity loss calculated where ``mask == True``
@@ -287,11 +351,13 @@ def sparsity(cube, mask=None):
 
 def UV_sparsity(vis, qs, q_max):
     r"""
-    Enforce a sparsity prior for all :math:`q = \sqrt{u^2 + v^2}` points larger than :math:`q_\mathrm{max}`.
+    Enforce a sparsity prior for all :math:`q = \sqrt{u^2 + v^2}` points larger than 
+    :math:`q_\mathrm{max}`.
 
     Args:
         vis (torch.double) : visibility cube of (nchan, npix, npix//2 +1, 2)
-        qs: numpy array corresponding to visibility coordinates. Dimensionality of (npix, npix//2)
+        qs: numpy array corresponding to visibility coordinates. Dimensionality of 
+            (npix, npix//2)
         q_max (float): maximum radial baseline
 
     Returns:
@@ -316,7 +382,8 @@ def UV_sparsity(vis, qs, q_max):
 
 def PSD(qs, psd, l):
     r"""
-    Apply a loss function corresponding to the power spectral density using a Gaussian process kernel.
+    Apply a loss function corresponding to the power spectral density using a Gaussian 
+    process kernel.
 
     Assumes an image plane kernel of
 
@@ -359,10 +426,18 @@ def PSD(qs, psd, l):
 
 def TSV(sky_cube):
     r"""
-    Calculate the total square variation (TSV) loss in the image dimension (R.A. and DEC). Following the definition in `EHT-IV 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_ Promotes the image to be edge smoothed which may be a better reoresentation of the truth image `K. Kuramochi et al 2018 <https://ui.adsabs.harvard.edu/abs/2018ApJ...858...56K/abstract>`_.
+    Calculate the total square variation (TSV) loss in the image dimension 
+    (R.A. and DEC). Following the definition in `EHT-IV 2019 
+    <https://ui.adsabs.harvard.edu/abs/2019ApJ...875L...4E/abstract>`_ Promotes the 
+    image to be edge smoothed which may be a better reoresentation of the truth image 
+    `K. Kuramochi et al 2018
+    <https://ui.adsabs.harvard.edu/abs/2018ApJ...858...56K/abstract>`_.
 
     Args:
-        sky_cube (any 3D tensor): the image cube array :math:`I_{lmv}`, where :math:`l` is R.A. in :math:`ndim=3`, :math:`m` is DEC in :math:`ndim=2`, and :math:`v` is the channel (velocity or frequency) dimension in :math:`ndim=1`. Should be in sky format representation.
+        sky_cube (any 3D tensor): the image cube array :math:`I_{lmv}`, where :math:`l` 
+            is R.A. in :math:`ndim=3`, :math:`m` is DEC in :math:`ndim=2`, and 
+            :math:`v` is the channel (velocity or frequency) dimension in 
+            :math:`ndim=1`. Should be in sky format representation.
 
     Returns:
         torch.double: total square variation loss

--- a/src/mpol/onedim.py
+++ b/src/mpol/onedim.py
@@ -1,5 +1,6 @@
-import numpy as np 
+import numpy as np
 from mpol.utils import torch2npy
+
 
 def radialI(icube, geom, chan=0, bins=None):
     r"""
@@ -9,12 +10,12 @@ def radialI(icube, geom, chan=0, bins=None):
     ----------
     icube : `mpol.images.ImageCube` object
         Instance of the MPoL `images.ImageCube` class
-    geom : dict 
+    geom : dict
         Dictionary of source geometry. Keys:
             "incl" : float, unit=[deg]
-                Inclination 
+                Inclination
             "Omega" : float, unit=[deg]
-                Position angle of the ascending node 
+                Position angle of the ascending node
             "omega" : float, unit=[deg]
                 Argument of periastron
             "dRA" : float, unit=[arcsec]
@@ -24,7 +25,7 @@ def radialI(icube, geom, chan=0, bins=None):
     chan : int, default=0
         Channel of the image cube corresponding to the desired image
     bins : array, default=None, unit=[arcsec]
-        Radial bin edges to use in calculating I(r). If None, bins will span 
+        Radial bin edges to use in calculating I(r). If None, bins will span
         the full image, with widths equal to the hypotenuse of the pixels
 
     Returns
@@ -59,12 +60,12 @@ def radialI(icube, geom, chan=0, bins=None):
     bin_counts, bin_edges = np.histogram(a=rr, bins=bins, weights=None)
 
     # cumulative binned brightness in each annulus
-    Is, _ = np.histogram(a=rr, bins=bins, 
-                         weights=torch2npy(icube.sky_cube[chan]).ravel()
-                         )
+    Is, _ = np.histogram(
+        a=rr, bins=bins, weights=torch2npy(icube.sky_cube[chan]).ravel()
+    )
 
     # mask empty bins
-    mask = (bin_counts == 0)
+    mask = bin_counts == 0
     Is = np.ma.masked_where(mask, Is)
 
     # average binned brightness in each annulus
@@ -77,44 +78,44 @@ def radialI(icube, geom, chan=0, bins=None):
 
 def radialV(fcube, geom, rescale_flux, chan=0, bins=None):
     r"""
-    Obtain the 1D (radial) visibility model V(q) corresponding to a 2D MPoL 
-    image. 
+    Obtain the 1D (radial) visibility model V(q) corresponding to a 2D MPoL
+    image.
 
     Parameters
     ----------
     fcube : `~mpol.fourier.FourierCube` object
         Instance of the MPoL `fourier.FourierCube` class
-    geom : dict 
+    geom : dict
         Dictionary of source geometry. Keys:
             "incl" : float, unit=[deg]
-                Inclination 
+                Inclination
             "Omega" : float, unit=[deg]
-                Position angle of the ascending node 
+                Position angle of the ascending node
             "omega" : float, unit=[deg]
                 Argument of periastron
             "dRA" : float, unit=[arcsec]
-                Phase center offset in right ascension. Positive is west of north. 
+                Phase center offset in right ascension. Positive is west of north.
             "dDec" : float, unit=[arcsec]
                 Phase center offset in declination
     rescale_flux : bool
-        If True, the visibility amplitudes are rescaled to account 
-        for the difference between the inclined (observed) brightness and the 
-        assumed face-on brightness, assuming the emission is optically thick. 
+        If True, the visibility amplitudes are rescaled to account
+        for the difference between the inclined (observed) brightness and the
+        assumed face-on brightness, assuming the emission is optically thick.
         The source's integrated (2D) flux is assumed to be:
         :math:`F = \cos(i) \int_r^{r=R}{I(r) 2 \pi r dr}`.
-        No rescaling would be appropriate in the optically thin limit. 
+        No rescaling would be appropriate in the optically thin limit.
     chan : int, default=0
-        Channel of the image cube corresponding to the desired image        
+        Channel of the image cube corresponding to the desired image
     bins : array, default=None, unit=[k\lambda]
-        Baseline bin edges to use in calculating V(q). If None, bins will span 
-        the model baseline distribution, with widths equal to the hypotenuse of 
+        Baseline bin edges to use in calculating V(q). If None, bins will span
+        the model baseline distribution, with widths equal to the hypotenuse of
         the (u, v) coordinates
 
     Returns
     -------
     bin_centers : array, unit=:math:[`k\lambda`]
         Baselines corresponding to `u` and `v`
-    Vs : array, unit=[Jy] 
+    Vs : array, unit=[Jy]
         Visibility amplitudes at `q`
 
     Notes
@@ -126,19 +127,21 @@ def radialV(fcube, geom, rescale_flux, chan=0, bins=None):
     # projected model (u,v) points [k\lambda]
     uu, vv = fcube.coords.sky_u_centers_2D, fcube.coords.sky_v_centers_2D
 
-    # visibilities 
+    # visibilities
     V = torch2npy(fcube.ground_vis[chan]).ravel()
 
     # phase-shift the visibilities
-    Vp = apply_phase_shift(uu.ravel() * 1e3, vv.ravel() * 1e3, V, geom["dRA"], 
-                           geom["dDec"], inverse=True)
-    
+    Vp = apply_phase_shift(
+        uu.ravel() * 1e3, vv.ravel() * 1e3, V, geom["dRA"], geom["dDec"], inverse=True
+    )
+
     # deproject the (u,v) points
-    up, vp, _ = deproject(uu.ravel() * 1e3, vv.ravel() * 1e3, geom["incl"], 
-                          geom["Omega"])
+    up, vp, _ = deproject(
+        uu.ravel() * 1e3, vv.ravel() * 1e3, geom["incl"], geom["Omega"]
+    )
 
     # if the source is optically thick, rescale the deprojected V(q)
-    if rescale_flux: 
+    if rescale_flux:
         Vp.real /= np.cos(geom["incl"] * np.pi / 180)
 
     # convert back to [k\lambda]
@@ -146,7 +149,7 @@ def radialV(fcube, geom, rescale_flux, chan=0, bins=None):
     vp /= 1e3
 
     # deprojected baselines
-    qq = np.hypot(up, vp) 
+    qq = np.hypot(up, vp)
 
     if bins is None:
         # choose sensible bin size and range
@@ -159,12 +162,12 @@ def radialV(fcube, geom, rescale_flux, chan=0, bins=None):
     Vs, _ = np.histogram(a=qq, bins=bins, weights=Vp)
 
     # mask empty bins
-    mask = (bin_counts == 0)
+    mask = bin_counts == 0
     Vs = np.ma.masked_where(mask, Vs)
 
     # average binned visibility amplitude in each annulus
     Vs /= bin_counts
-    
+
     bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
 
     return bin_centers, Vs

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.colors as mco 
+import matplotlib.colors as mco
 from matplotlib.patches import Ellipse
 import torch
 
@@ -12,9 +12,12 @@ from mpol.onedim import radialI, radialV
 from mpol.utils import loglinspace, torch2npy, packed_cube_to_sky_cube
 from mpol.input_output import ProcessFitsImage
 
-def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetric=False):
+
+def get_image_cmap_norm(
+    image, stretch="power", gamma=1.0, asinh_a=0.02, symmetric=False
+):
     """
-    Get a colormap normalization to apply to an image. 
+    Get a colormap normalization to apply to an image.
 
     image : array
         2D image array.
@@ -26,7 +29,7 @@ def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetr
         gamma=1.0 yields a linear colormap.
     asinh_a : float, default = 0.02
         Scale parameter for an asinh stretch.
-    symmetric : bool, default=False 
+    symmetric : bool, default=False
         Whether the colormap is symmetric about 0
     """
     if symmetric is True:
@@ -35,26 +38,27 @@ def get_image_cmap_norm(image, stretch='power', gamma=1.0, asinh_a=0.02, symmetr
 
     else:
         vmax, vmin = image.max(), image.min()
-        if stretch == 'power':
+        if stretch == "power":
             vmin = 0
 
-    if stretch == 'power':
-        norm = mco.PowerNorm(gamma, vmin, vmax)    
-    
-    elif stretch == 'asinh':
-        norm = simple_norm(image, stretch='asinh', asinh_a=asinh_a, 
-                        min_cut=vmin, max_cut=vmax)
+    if stretch == "power":
+        norm = mco.PowerNorm(gamma, vmin, vmax)
+
+    elif stretch == "asinh":
+        norm = simple_norm(
+            image, stretch="asinh", asinh_a=asinh_a, min_cut=vmin, max_cut=vmax
+        )
 
     else:
         raise ValueError("'stretch' must be one of 'asinh' or 'power'.")
-    
+
     return norm
 
 
 def get_residual_image(model, u, v, V, weights, robust=0.5):
-    """ 
+    """
     Get a dirty image and colormap normalization for residual visibilities,
-    the difference of observed visibilities and an MPoL model sampled at the 
+    the difference of observed visibilities and an MPoL model sampled at the
     observed (u,v) points.
 
     Parameters
@@ -69,7 +73,7 @@ def get_residual_image(model, u, v, V, weights, robust=0.5):
     weights : array, unit=[Jy^-2]
         Data weights
     robust : float, default=0.5
-        Robust weighting parameter used to create the dirty image of the 
+        Robust weighting parameter used to create the dirty image of the
         residual visibilities
 
     Returns
@@ -89,28 +93,28 @@ def get_residual_image(model, u, v, V, weights, robust=0.5):
         data_re=np.real(vis_resid),
         data_im=np.imag(vis_resid),
     )
-    im_resid, _ = resid_imager.get_dirty_image(weighting="briggs", 
-                                               robust=robust, 
-                                               unit='Jy/arcsec^2'
-                                               )
+    im_resid, _ = resid_imager.get_dirty_image(
+        weighting="briggs", robust=robust, unit="Jy/arcsec^2"
+    )
     # `get_vis_residuals` has already selected a single channel
     im_resid = np.squeeze(im_resid)
-    
-    norm_resid = get_image_cmap_norm(im_resid, 
-                                     stretch='power', 
-                                     gamma=1, 
-                                     symmetric=True
-                                     )
+
+    norm_resid = get_image_cmap_norm(im_resid, stretch="power", gamma=1, symmetric=True)
 
     return im_resid, norm_resid
 
 
-def plot_image(image, extent, cmap="inferno", norm=None, ax=None, 
-               clab=r"I [Jy arcsec$^{-2}$]",
-               xlab=r"$\Delta \alpha \cos \delta$ [${}^{\prime\prime}$]",
-               ylab=r"$\Delta \delta$ [${}^{\prime\prime}$]",
-               ):
-    r""" 
+def plot_image(
+    image,
+    extent,
+    cmap="inferno",
+    norm=None,
+    ax=None,
+    clab=r"I [Jy arcsec$^{-2}$]",
+    xlab=r"$\Delta \alpha \cos \delta$ [${}^{\prime\prime}$]",
+    ylab=r"$\Delta \delta$ [${}^{\prime\prime}$]",
+):
+    r"""
     Wrapper for plt.imshow, with colorbar and colormap normalization.
 
     Parameters
@@ -160,14 +164,22 @@ def plot_image(image, extent, cmap="inferno", norm=None, ax=None,
 
     ax.set_xlabel(xlab)
     ax.set_ylabel(ylab)
-    
+
     return im, cbar
 
 
-def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=None, 
-    phi_edges=None, q_edges1d=None, show_datapoints=False, save_prefix=None):
+def vis_histogram_fig(
+    dataset,
+    bin_quantity="count",
+    bin_label=None,
+    q_edges=None,
+    phi_edges=None,
+    q_edges1d=None,
+    show_datapoints=False,
+    save_prefix=None,
+):
     r"""
-    Generate a figure with 1d and 2d histograms of (u,v)-plane coverage. 
+    Generate a figure with 1d and 2d histograms of (u,v)-plane coverage.
     Histograms can show different data; see `bin_quantity` parameter.
 
     Parameters
@@ -179,21 +191,21 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
             - 'weight' bins points by the data weight (inherited from `dataset`)
             - 'vis_real' bins points by data Re(V)
             - 'vis_imag' bins points by data Im(V)
-            - A user-supplied numpy.ndarray to be used as 'weights' in np.histogram 
+            - A user-supplied numpy.ndarray to be used as 'weights' in np.histogram
     bin_label : str, default=None
         Label for 1d histogram y-axis and 2d histogram colorbar.
-    q_edges : array, optional (default=None), unit=:math:[`k\lambda`] 
-        Radial bin edges for the 1d and 2d histogram. If `None`, defaults to 
-        12 log-linearly radial bins over [0, 1.1 * maximum baseline in 
+    q_edges : array, optional (default=None), unit=:math:[`k\lambda`]
+        Radial bin edges for the 1d and 2d histogram. If `None`, defaults to
+        12 log-linearly radial bins over [0, 1.1 * maximum baseline in
         `dataset`].
-    phi_edges : array, optional (default=None), unit=[rad] 
-        Azimuthal bin edges for the 2d histogram. If `None`, defaults to 
+    phi_edges : array, optional (default=None), unit=[rad]
+        Azimuthal bin edges for the 2d histogram. If `None`, defaults to
         16 bins over [-\pi, \pi]
     q_edges1d : array, optional (default=None), unit=:math:[`k\lambda`]
-        Radial bin edges for a second 1d histogram. If `None`, defaults to 
+        Radial bin edges for a second 1d histogram. If `None`, defaults to
         50 bins equispaced over [0, 1.1 * maximum baseline in `dataset`].
-    show_datapoints : bool, default = False 
-        Whether to overplot the raw visibilities in `dataset` on the 2d 
+    show_datapoints : bool, default = False
+        Whether to overplot the raw visibilities in `dataset` on the 2d
         histogram.
     save_prefix : string, default = None
         Prefix for saved figure name. If None, the figure won't be saved
@@ -207,7 +219,7 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
 
     Notes
     -----
-    No assumption or correction is made concerning whether the (u,v) distances 
+    No assumption or correction is made concerning whether the (u,v) distances
     are projected or deprojected.
     """
 
@@ -224,43 +236,44 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
     qs = dataset.coords.packed_q_centers_2D[stacked_mask]
     phis = dataset.coords.packed_phi_centers_2D[stacked_mask]
 
-    if isinstance(bin_quantity, np.ndarray): 
+    if isinstance(bin_quantity, np.ndarray):
         weights = bin_quantity
-        hist_lab = bin_label 
+        hist_lab = bin_label
 
-    elif bin_quantity == 'count':
+    elif bin_quantity == "count":
         weights = None
-        hist_lab = 'Count'
-        
-    elif bin_quantity == 'weight':
+        hist_lab = "Count"
+
+    elif bin_quantity == "weight":
         weights = np.copy(weight_npy)
-        hist_lab = 'Weight'
+        hist_lab = "Weight"
 
-    elif bin_quantity == 'vis_real':
+    elif bin_quantity == "vis_real":
         weights = np.abs(np.real(vis_npy))
-        hist_lab = '|Re(V)|'
+        hist_lab = "|Re(V)|"
 
-    elif bin_quantity == 'vis_imag':
+    elif bin_quantity == "vis_imag":
         weights = np.abs(np.imag(vis_npy))
-        hist_lab = '|Im(V)|'
+        hist_lab = "|Im(V)|"
 
     else:
-        supported_q = ['count', 'weight', 'vis_real', 'vis_imag']
-        raise ValueError("`bin_quantity` ({}) must be one of " 
-                        "{}, or a user-provided numpy "
-                        " array".format(bin_quantity, supported_q))
-
+        supported_q = ["count", "weight", "vis_real", "vis_imag"]
+        raise ValueError(
+            "`bin_quantity` ({}) must be one of "
+            "{}, or a user-provided numpy "
+            " array".format(bin_quantity, supported_q)
+        )
 
     # buffer to include longest baselines in last bin
-    pad_factor = 1.1 
+    pad_factor = 1.1
 
     if q_edges1d is None:
         # 1d histogram with uniform bins
         q_edges1d = np.arange(0, qs.max() * pad_factor, 50)
 
     bin_lab = None
-    if all(np.diff(q_edges1d)==np.diff(q_edges1d)[0]):
-        bin_lab = r'Bin size {:.0f} k$\lambda$'.format(np.diff(q_edges1d)[0])
+    if all(np.diff(q_edges1d) == np.diff(q_edges1d)[0]):
+        bin_lab = r"Bin size {:.0f} k$\lambda$".format(np.diff(q_edges1d)[0])
 
     # 2d histogram bins
     if q_edges is None:
@@ -268,26 +281,30 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
     if phi_edges is None:
         phi_edges = np.linspace(-np.pi, np.pi, num=16 + 1)
 
-    H2d, _, _ = np.histogram2d(qs, phis, weights=weights, 
-                                bins=[q_edges, phi_edges])
+    H2d, _, _ = np.histogram2d(qs, phis, weights=weights, bins=[q_edges, phi_edges])
 
+    fig = plt.figure(figsize=(14, 6), tight_layout=True)
 
-    fig = plt.figure(figsize=(14,6), tight_layout=True)
-    
     # 1d histogram with polar plot bins
     ax0 = fig.add_subplot(221)
-    ax0.hist(qs, q_edges, weights=weights, fc='#A4A4A4', ec=(0,0,0,0.3), 
-            label='Polar plot bins')
+    ax0.hist(
+        qs,
+        q_edges,
+        weights=weights,
+        fc="#A4A4A4",
+        ec=(0, 0, 0, 0.3),
+        label="Polar plot bins",
+    )
     ax0.legend()
     ax0.set_ylabel(hist_lab)
-    
+
     # 1d histogram with (by default) uniform bins
     ax1 = fig.add_subplot(223, sharex=ax0)
-    ax1.hist(qs, q_edges1d, weights=weights, fc='#A93226', label=bin_lab)
+    ax1.hist(qs, q_edges1d, weights=weights, fc="#A93226", label=bin_lab)
     if bin_lab:
         ax1.legend()
     ax1.set_ylabel(hist_lab)
-    ax1.set_xlabel(r'Baseline [k$\lambda$]')
+    ax1.set_xlabel(r"Baseline [k$\lambda$]")
 
     # 2d polar histogram
     ax2 = fig.add_subplot(122, polar=True)
@@ -303,13 +320,13 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
     norm = mco.LogNorm(vmin=vmin)
 
     im = ax2.pcolormesh(
-        phi_edges, 
+        phi_edges,
         q_edges,
         H2d,
         shading="flat",
         norm=norm,
         cmap=cmap,
-        ec=(0,0,0,0.3),
+        ec=(0, 0, 0, 0.3),
         lw=0.3,
     )
 
@@ -320,12 +337,11 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
 
     if show_datapoints:
         # plot raw visibilities
-        ax2.scatter(phis, qs, s=1.5, rasterized=True, linewidths=0.0, c="k", 
-                    alpha=0.3)
+        ax2.scatter(phis, qs, s=1.5, rasterized=True, linewidths=0.0, c="k", alpha=0.3)
 
     if save_prefix is not None:
-        fig.savefig(save_prefix + '_vis_histogram.png', dpi=300)
-    
+        fig.savefig(save_prefix + "_vis_histogram.png", dpi=300)
+
     plt.close()
 
     return fig, (ax0, ax1, ax2)
@@ -333,13 +349,13 @@ def vis_histogram_fig(dataset, bin_quantity='count', bin_label=None, q_edges=Non
 
 def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
     r"""
-    Generate a figure showing (u,v) coverage in train and test sets split from 
+    Generate a figure showing (u,v) coverage in train and test sets split from
     a parent dataset.
 
     Parameters
     ----------
     splitter : `mpol.crossval.RandomCellSplitGridded` object
-        Iterator that returns a `(train, test)` pair of `GriddedDataset` 
+        Iterator that returns a `(train, test)` pair of `GriddedDataset`
         for each iteration.
     channel : int, default=0
         Channel (of the datasets in `splitter`) to use to generate figure
@@ -355,18 +371,18 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
 
     Notes
     -----
-    No assumption or correction is made concerning whether the (u,v) distances 
+    No assumption or correction is made concerning whether the (u,v) distances
     are projected or deprojected.
     """
-    fig, axes = plt.subplots(nrows=2, ncols=splitter.k, figsize=(10,3))
+    fig, axes = plt.subplots(nrows=2, ncols=splitter.k, figsize=(10, 3))
 
-    cmap_train = mco.ListedColormap(['none', 'black'])
-    cmap_test = mco.ListedColormap(['none', 'red'])
-    
-    kw = {"fontsize":8}
-    image_kw = {"origin":"lower", "interpolation":"none"}
+    cmap_train = mco.ListedColormap(["none", "black"])
+    cmap_test = mco.ListedColormap(["none", "red"])
 
-    fig.suptitle('Training data: black, test data: red', **kw)
+    kw = {"fontsize": 8}
+    image_kw = {"origin": "lower", "interpolation": "none"}
+
+    fig.suptitle("Training data: black, test data: red", **kw)
 
     for ii, (train, test) in enumerate(splitter):
         train_mask = torch2npy(train.ground_mask[channel])
@@ -384,30 +400,40 @@ def split_diagnostics_fig(splitter, channel=0, save_prefix=None):
         aa.xaxis.set_ticklabels([])
         aa.yaxis.set_ticklabels([])
 
-    ax = axes[1,-1]
-    ax.set_xlabel(r'u [M$\lambda$]', **kw)
-    ax.set_ylabel(r'v [M$\lambda$]', **kw)
+    ax = axes[1, -1]
+    ax.set_xlabel(r"u [M$\lambda$]", **kw)
+    ax.set_ylabel(r"v [M$\lambda$]", **kw)
     ax.yaxis.set_ticks_position("both")
-    ax.yaxis.tick_right()    
-    ax.yaxis.set_label_position("right") 
+    ax.yaxis.tick_right()
+    ax.yaxis.set_label_position("right")
 
-    fig.subplots_adjust(hspace=0.02, wspace=0, left=0.03, right=0.92, top=0.9, bottom=0.1)
+    fig.subplots_adjust(
+        hspace=0.02, wspace=0, left=0.03, right=0.92, top=0.9, bottom=0.1
+    )
 
     if save_prefix is not None:
-        fig.savefig(save_prefix + '_split_diag.png', dpi=300)
-    
+        fig.savefig(save_prefix + "_split_diag.png", dpi=300)
+
     plt.close()
 
     return fig, axes
 
 
-def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None, 
-                          old_model_image=None, old_model_epoch=None,
-                          kfold=None, epoch=None,
-                          channel=0, save_prefix=None):
+def train_diagnostics_fig(
+    model,
+    losses=None,
+    learn_rates=None,
+    fluxes=None,
+    old_model_image=None,
+    old_model_epoch=None,
+    kfold=None,
+    epoch=None,
+    channel=0,
+    save_prefix=None,
+):
     """
-    Figure for model diagnostics at a given model state during an optimization loop. 
-    
+    Figure for model diagnostics at a given model state during an optimization loop.
+
     Plots:
         - model image
         - flux of model image
@@ -423,11 +449,11 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None,
     losses : list
         Loss value at each epoch in the training loop
     learn_rates : list
-        Learning rate at each epoch in the training loop  
+        Learning rate at each epoch in the training loop
     fluxes : list
         Total flux in model image at each epoch in the training loop
     old_model_image : 2D image array, default=None
-        Model image of a previous epoch for comparison to current image  
+        Model image of a previous epoch for comparison to current image
     old_model_epoch : int
         Epoch of `old_model_image`
     kfold : int, default=None
@@ -435,7 +461,7 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None,
     epoch : int, default=None
         Current training epoch
     channel : int, default=0
-        Channel (of the datasets in `splitter`) to use to generate figure        
+        Channel (of the datasets in `splitter`) to use to generate figure
     save_prefix : str, default = None
         Prefix for saved figure name. If None, the figure won't be saved
 
@@ -449,8 +475,11 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None,
     fig, axes = plt.subplots(ncols=2, nrows=2, figsize=(8, 8))
     axes[1][1].remove()
 
-    fig.suptitle(f"Pixel size {model.coords.cell_size * 1e3:.2f} mas, N_pix {model.coords.npix}\nk-fold {kfold}, epoch {epoch}", fontsize=10)
-    
+    fig.suptitle(
+        f"Pixel size {model.coords.cell_size * 1e3:.2f} mas, N_pix {model.coords.npix}\nk-fold {kfold}, epoch {epoch}",
+        fontsize=10,
+    )
+
     mod_im = torch2npy(model.icube.sky_cube[channel])
     mod_grad = torch2npy(packed_cube_to_sky_cube(model.bcube.base_cube.grad)[channel])
     extent = model.icube.coords.img_ext
@@ -461,53 +490,70 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None,
     # ax.set_title("Model image")
 
     # model image (asinh colormap)
-    ax = axes[0,0]
-    plot_image(mod_im, extent, ax=ax, xlab='', ylab='', norm=get_image_cmap_norm(mod_im, stretch='asinh'))
+    ax = axes[0, 0]
+    plot_image(
+        mod_im,
+        extent,
+        ax=ax,
+        xlab="",
+        ylab="",
+        norm=get_image_cmap_norm(mod_im, stretch="asinh"),
+    )
     ax.set_title("Model image", fontsize=10)
 
     # gradient image
-    ax = axes[1,0]
+    ax = axes[1, 0]
     plot_image(mod_grad, extent, ax=ax)
     ax.set_title("Gradient image", fontsize=10)
 
     if old_model_image is not None:
         # current model image - model image at last stored epoch
-        ax = axes[0,1]
+        ax = axes[0, 1]
         diff_image = mod_im - old_model_image
         diff_im_norm = get_image_cmap_norm(diff_image, symmetric=True)
-        plot_image(diff_image, extent, cmap='RdBu_r', ax=ax, xlab='', ylab='', norm=diff_im_norm)
+        plot_image(
+            diff_image,
+            extent,
+            cmap="RdBu_r",
+            ax=ax,
+            xlab="",
+            ylab="",
+            norm=diff_im_norm,
+        )
         ax.set_title(f"Difference (epoch {epoch} - {old_model_epoch})", fontsize=10)
-        
+
     if losses is not None:
         # loss function
         ax = fig.add_subplot(426)
-        ax.semilogy(losses, 'k', label=f"{losses[-1]:.3f}")
-        ax.legend(loc='upper right')
+        ax.semilogy(losses, "k", label=f"{losses[-1]:.3f}")
+        ax.legend(loc="upper right")
         ax.xaxis.set_tick_params(labelbottom=False)
-        ax.set_ylabel('Loss')
+        ax.set_ylabel("Loss")
 
-    if learn_rates is not None:    
+    if learn_rates is not None:
         # learning rate
         ax = fig.add_subplot(428)
-        ax.plot(learn_rates, 'k', label=f"{learn_rates[-1]:.3e}")
-        ax.legend(loc='upper right')
-        ax.set_xlabel('Epoch')
-        ax.set_ylabel('Learn rate')
+        ax.plot(learn_rates, "k", label=f"{learn_rates[-1]:.3e}")
+        ax.legend(loc="upper right")
+        ax.set_xlabel("Epoch")
+        ax.set_ylabel("Learn rate")
 
     plt.tight_layout()
 
     if fluxes is not None:
-        # total flux in model image 
+        # total flux in model image
         ax = fig.add_axes([0.08, 0.465, 0.3, 0.08])
-        ax.plot(fluxes, 'k', label=f"{fluxes[-1]:.4f}")
-        ax.legend(loc='upper right', fontsize=8)
+        ax.plot(fluxes, "k", label=f"{fluxes[-1]:.4f}")
+        ax.legend(loc="upper right", fontsize=8)
         ax.tick_params(labelsize=8)
         # ax.set_xlabel('Epoch', fontsize=8)
-        ax.set_ylabel('Flux [Jy]', fontsize=8)
+        ax.set_ylabel("Flux [Jy]", fontsize=8)
 
     if save_prefix is not None:
-        fig.savefig(save_prefix + f"_train_diag_kfold{kfold}_epoch{epoch:05d}.png", dpi=300)
-    
+        fig.savefig(
+            save_prefix + f"_train_diag_kfold{kfold}_epoch{epoch:05d}.png", dpi=300
+        )
+
     plt.close()
 
     return fig, axes
@@ -515,9 +561,9 @@ def train_diagnostics_fig(model, losses=None, learn_rates=None, fluxes=None,
 
 def crossval_diagnostics_fig(cv, title="", save_prefix=None):
     """
-    Figure for model diagnostics of a cross-validation run. 
-    
-    Plots: 
+    Figure for model diagnostics of a cross-validation run.
+
+    Plots:
         - loss evolution for each k-fold
         - cross-validation score per k-fold
 
@@ -537,19 +583,21 @@ def crossval_diagnostics_fig(cv, title="", save_prefix=None):
     axes : Matplotlib `~.axes.Axes` class
         Axes of the generated figure
     """
-    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(6,3))
+    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(6, 3))
 
     title += f"\nRegularizers {cv.regularizers}\nSplit method: {cv.split_method}, CV score {cv.score['mean']:.3f} +- {cv.score['std']:.3f}"
     fig.suptitle(title, fontsize=6)
 
-    axes[0].plot(cv.score['all'], 'k.')
-    axes[0].axhline(y=cv.score['mean'], c='r', ls='--', label=r'$\mu$')
-    axes[0].axhline(y=cv.score['mean'] + cv.score['std'], c='c', ls=':', label=r'$\pm 1 \sigma$')
-    axes[0].axhline(y=cv.score['mean'] - cv.score['std'], c='c', ls=':')
+    axes[0].plot(cv.score["all"], "k.")
+    axes[0].axhline(y=cv.score["mean"], c="r", ls="--", label=r"$\mu$")
+    axes[0].axhline(
+        y=cv.score["mean"] + cv.score["std"], c="c", ls=":", label=r"$\pm 1 \sigma$"
+    )
+    axes[0].axhline(y=cv.score["mean"] - cv.score["std"], c="c", ls=":")
 
-    for i,l in enumerate(cv.diagnostics['loss_histories']):
+    for i, l in enumerate(cv.diagnostics["loss_histories"]):
         axes[1].loglog(l, label=f"k-fold {i}")
-    
+
     axes[0].legend(fontsize=6)
     axes[0].set_xlabel("k-fold")
     axes[0].set_ylabel("Score")
@@ -557,27 +605,36 @@ def crossval_diagnostics_fig(cv, title="", save_prefix=None):
     axes[1].legend(fontsize=6)
     axes[1].set_xlabel("Epoch")
     axes[1].set_ylabel("Loss")
-    
+
     plt.tight_layout()
 
     if save_prefix is not None:
         fig.savefig(save_prefix + "_crossval_diagnostics.png", dpi=300)
-    
+
     plt.close()
 
     return fig, axes
 
 
-def image_comparison_fig(model, u, v, V, weights, robust=0.5, 
-                         clean_fits=None, share_cscale=False, 
-                         xzoom=[None, None], yzoom=[None, None],
-                         title="",
-                         channel=0, 
-                         save_prefix=None):
+def image_comparison_fig(
+    model,
+    u,
+    v,
+    V,
+    weights,
+    robust=0.5,
+    clean_fits=None,
+    share_cscale=False,
+    xzoom=[None, None],
+    yzoom=[None, None],
+    title="",
+    channel=0,
+    save_prefix=None,
+):
     """
-    Figure for comparison of MPoL model image to other image models. 
-    
-    Plots: 
+    Figure for comparison of MPoL model image to other image models.
+
+    Plots:
         - dirty image
         - MPoL model image
         - MPoL residual visibilities imaged
@@ -592,22 +649,22 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
     V : array, unit=[Jy]
         Data visibility amplitudes
     weights : array, unit=[Jy^-2]
-        Data weights        
+        Data weights
     robust : float, default=0.5
-        Robust weighting parameter used to create the dirty image of the 
-        observed visibilities and separately of the MPoL residual visibilities  
+        Robust weighting parameter used to create the dirty image of the
+        observed visibilities and separately of the MPoL residual visibilities
     clean_fits : str, default=None
         Path to a clean .fits image
     share_cscale : bool, default=False
-        Whether the MPoL model image, dirty image and clean image share the 
+        Whether the MPoL model image, dirty image and clean image share the
         same colorscale
     xzoom, yzoom : list of float, default = [None, None]
-        X- and y- axis limits to zoom the images to. `xzoom` and `yzoom` should 
+        X- and y- axis limits to zoom the images to. `xzoom` and `yzoom` should
         both list values in ascending order (e.g. [-2, 3], not [3, -2])
     title : str, default=""
         Figure super-title
     channel : int, default=0
-        Channel of the model to use to generate figure        
+        Channel of the model to use to generate figure
     save_prefix : string, default = None
         Prefix for saved figure name. If None, the figure won't be saved
 
@@ -618,7 +675,7 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
     axes : Matplotlib `~.axes.Axes` class
         Axes of the generated figure
     """
-    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10,10))
+    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10, 10))
 
     title += f"\nMPoL pixel size {model.coords.cell_size * 1e3:.2f} mas, N_pix {model.coords.npix}"
     if share_cscale:
@@ -627,23 +684,18 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
 
     # get MPoL model image
     mod_im = torch2npy(model.icube.sky_cube[channel])
-    total_flux = model.coords.cell_size ** 2 * np.sum(mod_im)
+    total_flux = model.coords.cell_size**2 * np.sum(mod_im)
 
     # get imaged MPoL residual visibilities
     im_resid, norm_resid = get_residual_image(model, u, v, V, weights, robust=robust)
 
     # get dirty image
     imager = DirtyImager(
-        coords=model.coords,
-        uu=u,
-        vv=v,
-        weight=weights,
-        data_re=V.real,
-        data_im=V.imag
+        coords=model.coords, uu=u, vv=v, weight=weights, data_re=V.real, data_im=V.imag
     )
-    dirty_im, dirty_beam = imager.get_dirty_image(weighting="briggs",
-                                        robust=robust,
-                                        unit="Jy/arcsec^2")
+    dirty_im, dirty_beam = imager.get_dirty_image(
+        weighting="briggs", robust=robust, unit="Jy/arcsec^2"
+    )
     dirty_im = np.squeeze(dirty_im)
 
     # get clean image and beam
@@ -652,56 +704,79 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
         clean_im, clean_im_ext, clean_beam = fits_obj.get_image(beam=True)
 
     # set image colorscales
-    norm_mod = get_image_cmap_norm(mod_im, stretch='asinh')
+    norm_mod = get_image_cmap_norm(mod_im, stretch="asinh")
     if share_cscale:
         norm_dirty = norm_clean = norm_mod
     else:
-        norm_dirty = get_image_cmap_norm(dirty_im, stretch='asinh')
+        norm_dirty = get_image_cmap_norm(dirty_im, stretch="asinh")
         if clean_fits is not None:
-            norm_clean = get_image_cmap_norm(clean_im, stretch='asinh')
-    
+            norm_clean = get_image_cmap_norm(clean_im, stretch="asinh")
+
     # MPoL model image
-    plot_image(mod_im, extent=model.icube.coords.img_ext,
-                    ax=axes[0][1], norm=norm_mod, xlab='', ylab='')
+    plot_image(
+        mod_im,
+        extent=model.icube.coords.img_ext,
+        ax=axes[0][1],
+        norm=norm_mod,
+        xlab="",
+        ylab="",
+    )
 
     # imaged MPoL residual visibilities
-    plot_image(im_resid, extent=model.icube.coords.img_ext, 
-                ax=axes[1][1], norm=norm_resid, cmap='RdBu_r', xlab='', ylab='')
+    plot_image(
+        im_resid,
+        extent=model.icube.coords.img_ext,
+        ax=axes[1][1],
+        norm=norm_resid,
+        cmap="RdBu_r",
+        xlab="",
+        ylab="",
+    )
 
     # dirty image
-    plot_image(dirty_im, extent=model.icube.coords.img_ext,  
-                    ax=axes[0][0], norm=norm_dirty)
-    
+    plot_image(
+        dirty_im, extent=model.icube.coords.img_ext, ax=axes[0][0], norm=norm_dirty
+    )
+
     # clean image
     if clean_fits is not None:
-        plot_image(clean_im, extent=clean_im_ext, 
-                    ax=axes[1][0], norm=norm_clean, xlab='', ylab='')
-        
+        plot_image(
+            clean_im,
+            extent=clean_im_ext,
+            ax=axes[1][0],
+            norm=norm_clean,
+            xlab="",
+            ylab="",
+        )
+
         # add clean beam to plot
         if any(xzoom) and any(yzoom):
             beam_xy = (0.85 * xzoom[1], 0.85 * yzoom[0])
         else:
             beam_xy = (0.85 * axes[1][0].get_xlim()[1], 0.85 * axes[1][0].get_ylim()[0])
 
-        beam_ellipse = Ellipse(xy=beam_xy,
-                            width=clean_beam[0], 
-                            height=clean_beam[1], 
-                            angle=-clean_beam[2], 
-                            color='w'
-                            )
+        beam_ellipse = Ellipse(
+            xy=beam_xy,
+            width=clean_beam[0],
+            height=clean_beam[1],
+            angle=-clean_beam[2],
+            color="w",
+        )
         axes[1][0].add_artist(beam_ellipse)
 
     if any(xzoom) and any(yzoom):
-        for ii in [0,1]:
-            for jj in [0,1]:
+        for ii in [0, 1]:
+            for jj in [0, 1]:
                 axes[ii][jj].set_xlim(xzoom[1], xzoom[0])
                 axes[ii][jj].set_ylim(yzoom[0], yzoom[1])
 
     axes[0][0].set_title(f"Dirty image (robust {robust})")
     axes[0][1].set_title(f"MPoL image (flux {total_flux:.4f} Jy)")
-    axes[1][1].set_title(f"MPoL residual V imaged (robust {robust})")      
+    axes[1][1].set_title(f"MPoL residual V imaged (robust {robust})")
     if clean_fits is not None:
-        axes[1][0].set_title(f"Clean image (beam {clean_beam[0] * 1e3:.0f} $\\times$ {clean_beam[1] * 1e3:.0f} mas)")  
+        axes[1][0].set_title(
+            f"Clean image (beam {clean_beam[0] * 1e3:.0f} $\\times$ {clean_beam[1] * 1e3:.0f} mas)"
+        )
 
     plt.tight_layout()
 
@@ -713,12 +788,24 @@ def image_comparison_fig(model, u, v, V, weights, robust=0.5,
     return fig, axes
 
 
-def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False, 
-              bin_width=20e3, q_logx=True, title="", channel=0, save_prefix=None):
+def vis_1d_fig(
+    model,
+    u,
+    v,
+    V,
+    weights,
+    geom=None,
+    rescale_flux=False,
+    bin_width=20e3,
+    q_logx=True,
+    title="",
+    channel=0,
+    save_prefix=None,
+):
     """
-    Figure for comparison of 1D projected MPoL model visibilities and observed 
-        visibilities. 
-    
+    Figure for comparison of 1D projected MPoL model visibilities and observed
+        visibilities.
+
     Plots:
         - Re(V): observed and MPoL model (projected unless `geom` is supplied)
         - Residual Re(V): observed - MPoL model (projected unless `geom` is supplied)
@@ -734,14 +821,14 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     V : array, unit=[Jy]
         Data visibility amplitudes
     weights : array, unit=[Jy^-2]
-        Data weights        
+        Data weights
     geom : dict
-        Dictionary of source geometry. If passed in, visibilities will be 
+        Dictionary of source geometry. If passed in, visibilities will be
             deprojected prior to plotting. Keys:
                 "incl" : float, unit=[deg]
-                    Inclination 
+                    Inclination
                 "Omega" : float, unit=[deg]
-                    Position angle of the ascending node 
+                    Position angle of the ascending node
                 "omega" : float, unit=[deg]
                     Argument of periastron
                 "dRA" : float, unit=[arcsec]
@@ -749,12 +836,12 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
                 "dDec" : float, unit=[arcsec]
                     Phase center offset in declination.
     rescale_flux : bool
-        If True, the visibility amplitudes are rescaled to account 
-            for the difference between the inclined (observed) brightness and the 
-            assumed face-on brightness, assuming the emission is optically thick. 
+        If True, the visibility amplitudes are rescaled to account
+            for the difference between the inclined (observed) brightness and the
+            assumed face-on brightness, assuming the emission is optically thick.
             The source's integrated (2D) flux is assumed to be:
             :math:`F = \cos(i) \int_r^{r=R}{I(r) 2 \pi r dr}`.
-            No rescaling would be appropriate in the optically thin limit.                 
+            No rescaling would be appropriate in the optically thin limit.
     bin_width : float, default=20e3
         Bin size [klambda] for baselines
     q_logx : bool, default=True
@@ -762,7 +849,7 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     title : str, default=""
         Figure super-title
     channel : int, default=0
-        Channel of the model to use to generate figure        
+        Channel of the model to use to generate figure
     save_prefix : string, default = None
         Prefix for saved figure name. If None, the figure won't be saved
 
@@ -783,11 +870,17 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     # get MPoL residual and model visibilities
     Vresid, Vmod = get_vis_residuals(model, u, v, V, return_Vmod=True)
 
-    if geom is not None:    
+    if geom is not None:
         # phase-shift the visibilities
-        V = apply_phase_shift(u * 1e3, v * 1e3, V, geom["dRA"], geom["dDec"], inverse=True)
-        Vmod = apply_phase_shift(u * 1e3, v * 1e3, Vmod, geom["dRA"], geom["dDec"], inverse=True)
-        Vresid = apply_phase_shift(u * 1e3, v * 1e3, Vresid, geom["dRA"], geom["dDec"], inverse=True)
+        V = apply_phase_shift(
+            u * 1e3, v * 1e3, V, geom["dRA"], geom["dDec"], inverse=True
+        )
+        Vmod = apply_phase_shift(
+            u * 1e3, v * 1e3, Vmod, geom["dRA"], geom["dDec"], inverse=True
+        )
+        Vresid = apply_phase_shift(
+            u * 1e3, v * 1e3, Vresid, geom["dRA"], geom["dDec"], inverse=True
+        )
 
         # deproject the (u,v) points
         u, v, _ = deproject(u * 1e3, v * 1e3, geom["incl"], geom["Omega"])
@@ -796,7 +889,7 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
         v /= 1e3
 
         # if the source is optically thick, rescale the deprojected V(q)
-        if rescale_flux: 
+        if rescale_flux:
             V.real /= np.cos(geom["incl"] * np.pi / 180)
             Vmod.real /= np.cos(geom["incl"] * np.pi / 180)
             Vresid.real /= np.cos(geom["incl"] * np.pi / 180)
@@ -816,7 +909,7 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     amax_binVres_re = np.max(abs(binned_Vresid.V.real))
     amax_binVres_im = np.max(abs(binned_Vresid.V.imag))
 
-    fig, axes = plt.subplots(nrows=4, ncols=1, figsize=(10,8))
+    fig, axes = plt.subplots(nrows=4, ncols=1, figsize=(10, 8))
 
     if geom is None:
         title += "\nProjected visibilities"
@@ -827,44 +920,57 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     fig.suptitle(title)
 
     # *projected* Re(V) -- observed and MPoL model
-    axes[0].plot(qq, binned_Vtrue.V.real * 1e3, 'k.', 
-                    label=f"Obs., {bin_width / 1e3:.2f} k$\\lambda$ bins")
-    axes[0].plot(qq, binned_Vmod.V.real * 1e3, 'r.', 
-                    label='MPoL')
+    axes[0].plot(
+        qq,
+        binned_Vtrue.V.real * 1e3,
+        "k.",
+        label=f"Obs., {bin_width / 1e3:.2f} k$\\lambda$ bins",
+    )
+    axes[0].plot(qq, binned_Vmod.V.real * 1e3, "r.", label="MPoL")
     axes[0].legend()
 
     # *projected* Im(V) -- observed and MPoL model
-    axes[2].plot(qq, binned_Vtrue.V.imag * 1e3, 'k.')
-    axes[2].plot(qq, binned_Vmod.V.imag * 1e3, 'r.')
+    axes[2].plot(qq, binned_Vtrue.V.imag * 1e3, "k.")
+    axes[2].plot(qq, binned_Vmod.V.imag * 1e3, "r.")
 
     # *projected* residual Re(V) = observed - MPoL model
-    axes[1].plot(qq, binned_Vresid.V.real * 1e3, '.', c='#33C1FF',
-                    label=f"Mean {np.mean(binned_Vresid.V.real) * 1e3:.1e} mJy")
+    axes[1].plot(
+        qq,
+        binned_Vresid.V.real * 1e3,
+        ".",
+        c="#33C1FF",
+        label=f"Mean {np.mean(binned_Vresid.V.real) * 1e3:.1e} mJy",
+    )
     axes[1].legend()
 
     # *projected* residual Im(V) = observed - MPoL model
-    axes[3].plot(qq, binned_Vresid.V.imag * 1e3, '.', c='#33C1FF',
-                    label=f"Mean {np.mean(binned_Vresid.V.imag) * 1e3:.1e} mJy")
+    axes[3].plot(
+        qq,
+        binned_Vresid.V.imag * 1e3,
+        ".",
+        c="#33C1FF",
+        label=f"Mean {np.mean(binned_Vresid.V.imag) * 1e3:.1e} mJy",
+    )
     axes[3].legend()
 
     # y-lims on residual plots symmetric about 0
     axes[1].set_ylim(-amax_binVres_re * 1e3, amax_binVres_re * 1e3)
     axes[3].set_ylim(-amax_binVres_im * 1e3, amax_binVres_im * 1e3)
-    axes[1].axhline(y=0, ls='--', c='k')
-    axes[3].axhline(y=0, ls='--', c='k')
+    axes[1].axhline(y=0, ls="--", c="k")
+    axes[3].axhline(y=0, ls="--", c="k")
 
     for ii in range(4):
         axes[ii].set_xlim(0.9 * np.min(qq), 1.1 * np.max(qq))
         if q_logx:
-            axes[ii].set_xscale('log')
+            axes[ii].set_xscale("log")
         if ii < 3:
             axes[ii].xaxis.set_tick_params(labelbottom=False)
 
-    axes[0].set_ylabel('Re(V) [mJy]')
-    axes[1].set_ylabel('Resid. Re(V) [mJy]')            
-    axes[2].set_ylabel('Im(V) [mJy]')
-    axes[3].set_ylabel('Resid. Im(V) [mJy]')
-    axes[3].set_xlabel(r'Baseline [M$\lambda$]')
+    axes[0].set_ylabel("Re(V) [mJy]")
+    axes[1].set_ylabel("Resid. Re(V) [mJy]")
+    axes[2].set_ylabel("Im(V) [mJy]")
+    axes[3].set_ylabel("Resid. Im(V) [mJy]")
+    axes[3].set_xlabel(r"Baseline [M$\lambda$]")
 
     plt.tight_layout()
 
@@ -881,15 +987,27 @@ def vis_1d_fig(model, u, v, V, weights, geom=None, rescale_flux=False,
     plt.close()
 
     return fig, axes
-    
 
-def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None, 
-               rescale_flux=False, bin_width=20e3, q_logx=True, title="", 
-               channel=0, save_prefix=None):
+
+def radial_fig(
+    model,
+    geom,
+    u=None,
+    v=None,
+    V=None,
+    weights=None,
+    dist=None,
+    rescale_flux=False,
+    bin_width=20e3,
+    q_logx=True,
+    title="",
+    channel=0,
+    save_prefix=None,
+):
     """
     Figure for analysis of 1D (radial) brightness profile of MPoL model image,
-    using a user-supplied geometry. 
-    
+    using a user-supplied geometry.
+
     Plots:
         - MPoL model image
         - 1D (radial) brightness profile extracted from MPoL image (supply `dist` to show second x-axis in [AU])
@@ -904,9 +1022,9 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
         Dictionary of source geometry. Used to deproject image and visibilities.
             Keys:
                 "incl" : float, unit=[deg]
-                    Inclination 
+                    Inclination
                 "Omega" : float, unit=[deg]
-                    Position angle of the ascending node 
+                    Position angle of the ascending node
                 "omega" : float, unit=[deg]
                     Argument of periastron
                 "dRA" : float, unit=[arcsec]
@@ -918,16 +1036,16 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
     V : array, optional, unit=[Jy], default=None
         Data visibility amplitudes
     weights : array, optional, unit=[Jy^-2], default=None
-        Data weights        
+        Data weights
     dist : float, optional, unit = [AU], default = None
-        Distance to source, used to show second x-axis for I(r) in [AU]                  
+        Distance to source, used to show second x-axis for I(r) in [AU]
     rescale_flux : bool
-        If True, the visibility amplitudes are rescaled to account 
-        for the difference between the inclined (observed) brightness and the 
-        assumed face-on brightness, assuming the emission is optically thick. 
+        If True, the visibility amplitudes are rescaled to account
+        for the difference between the inclined (observed) brightness and the
+        assumed face-on brightness, assuming the emission is optically thick.
         The source's integrated (2D) flux is assumed to be:
         :math:`F = \cos(i) \int_r^{r=R}{I(r) 2 \pi r dr}`.
-        No rescaling would be appropriate in the optically thin limit.                 
+        No rescaling would be appropriate in the optically thin limit.
     bin_width : float, default=20e3
         Bin size [klambda] in which to bin observed visibility points
     q_logx : bool, default=True
@@ -935,7 +1053,7 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
     title : str, default=""
         Figure super-title
     channel : int, default=0
-        Channel of the model to use to generate figure        
+        Channel of the model to use to generate figure
     save_prefix : string, default = None
         Prefix for saved figure name. If None, the figure won't be saved
 
@@ -955,7 +1073,9 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
         from frank.utilities import UVDataBinner
 
         # phase-shift the observed visibilities
-        V = apply_phase_shift(u * 1e3, v * 1e3, V, geom["dRA"], geom["dDec"], inverse=True)
+        V = apply_phase_shift(
+            u * 1e3, v * 1e3, V, geom["dRA"], geom["dDec"], inverse=True
+        )
 
         # deproject the observed (u,v) points
         u, v, _ = deproject(u * 1e3, v * 1e3, geom["incl"], geom["Omega"])
@@ -964,7 +1084,7 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
         v /= 1e3
 
         # if the source is optically thick, rescale the deprojected V(q)
-        if rescale_flux: 
+        if rescale_flux:
             V.real /= np.cos(geom["incl"] * np.pi / 180)
             weights *= np.cos(geom["incl"] * np.pi / 180) ** 2
 
@@ -980,43 +1100,46 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
 
     # MPoL model image
     mod_im = torch2npy(model.icube.sky_cube[channel])
-    total_flux = model.coords.cell_size ** 2 * np.sum(mod_im)
+    total_flux = model.coords.cell_size**2 * np.sum(mod_im)
 
-
-    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10,10))
+    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(10, 10))
     axes = axes.ravel()
 
     title += f"\nGeometry (units: deg, arcsec):\n{geom}"
     fig.suptitle(title)
 
     # MPoL model image
-    norm_mod = get_image_cmap_norm(mod_im, stretch='asinh')    
+    norm_mod = get_image_cmap_norm(mod_im, stretch="asinh")
     plot_image(mod_im, extent=model.icube.coords.img_ext, ax=axes[0], norm=norm_mod)
-    
+
     # MPoL model I(r_arcsec)
-    axes[2].plot(rs, Is, 'r-', label='MPoL')
+    axes[2].plot(rs, Is, "r-", label="MPoL")
     axes[2].legend()
 
-    # I(r_AU) 
+    # I(r_AU)
     if dist is not None:
         ax2top = axes[2].twiny()
-        ax2top.plot(rs * dist, Is, 'r-')
+        ax2top.plot(rs * dist, Is, "r-")
 
     # Re(V) -- observed and MPoL model
     if not any(x is None for x in [u, v, V, weights]):
-        axes[1].plot(binned_Vtrue.uv / 1e6, binned_Vtrue.V.real * 1e3, 'k.', 
-                    label=f"Obs., {bin_width / 1e3:.2f} k$\\lambda$ bins")
-    axes[1].plot(q_mod / 1e3, V_mod.real * 1e3, 'r.-', label='MPoL')
+        axes[1].plot(
+            binned_Vtrue.uv / 1e6,
+            binned_Vtrue.V.real * 1e3,
+            "k.",
+            label=f"Obs., {bin_width / 1e3:.2f} k$\\lambda$ bins",
+        )
+    axes[1].plot(q_mod / 1e3, V_mod.real * 1e3, "r.-", label="MPoL")
     axes[1].legend()
 
     # Im(V) -- observed and MPoL model
     if not any(x is None for x in [u, v, V, weights]):
-        axes[3].plot(binned_Vtrue.uv / 1e6, binned_Vtrue.V.imag * 1e3, 'k.')
-    axes[3].plot(q_mod / 1e3, V_mod.imag * 1e3, 'r.-')
+        axes[3].plot(binned_Vtrue.uv / 1e6, binned_Vtrue.V.imag * 1e3, "k.")
+    axes[3].plot(q_mod / 1e3, V_mod.imag * 1e3, "r.-")
 
-    for ii in [1,3]:
+    for ii in [1, 3]:
         if q_logx:
-            axes[ii].set_xscale('log')
+            axes[ii].set_xscale("log")
         if not any(x is None for x in [u, v]):
             q_obs = np.hypot(u, v)
             axes[ii].set_xlim(right=1.1 * np.max(q_obs) / 1e3)
@@ -1024,26 +1147,25 @@ def radial_fig(model, geom, u=None, v=None, V=None, weights=None, dist=None,
             axes[ii].set_xlim(right=1.1 * np.max(q_mod) / 1e3)
 
     axes[0].set_title(f"MPoL image (flux {total_flux:.4f} Jy)")
-    axes[2].set_ylabel(r'I [Jy / arcsec$^2$]')
-    axes[2].set_xlabel(r'r [arcsec]')
+    axes[2].set_ylabel(r"I [Jy / arcsec$^2$]")
+    axes[2].set_xlabel(r"r [arcsec]")
     if dist is not None:
-        ax2top.spines['top'].set_color('#1A9E46')
-        ax2top.tick_params(axis='x', which='both', colors='#1A9E46')
-        ax2top.set_xlabel('r [AU]', color='#1A9E46')
+        ax2top.spines["top"].set_color("#1A9E46")
+        ax2top.tick_params(axis="x", which="both", colors="#1A9E46")
+        ax2top.set_xlabel("r [AU]", color="#1A9E46")
         xlims = axes[2].get_xlim()
         ax2top.set_xlim(np.multiply(xlims, dist))
-        
+
     axes[1].xaxis.set_tick_params(labelbottom=False)
-    axes[1].set_ylabel('Re(V) [mJy]')
-    axes[3].set_ylabel('Im(V) [mJy]')
-    axes[3].set_xlabel(r'Baseline [M$\lambda$]')
+    axes[1].set_ylabel("Re(V) [mJy]")
+    axes[3].set_ylabel("Im(V) [mJy]")
+    axes[3].set_xlabel(r"Baseline [M$\lambda$]")
 
     plt.tight_layout()
 
     if save_prefix is not None:
         fig.savefig(save_prefix + "_radial_profiles.png", dpi=300)
-    
+
     plt.close()
 
     return fig, axes
-    

--- a/src/mpol/precomposed.py
+++ b/src/mpol/precomposed.py
@@ -12,9 +12,11 @@ class SimpleNet(torch.nn.Module):
     Args:
         cell_size (float): the width of a pixel [arcseconds]
         npix (int): the number of pixels per image side
-        coords (GridCoords): an object already instantiated from the GridCoords class. If providing this, cannot provide ``cell_size`` or ``npix``.
+        coords (GridCoords): an object already instantiated from the GridCoords class. 
+            If providing this, cannot provide ``cell_size`` or ``npix``.
         nchan (int): the number of channels in the base cube. Default = 1.
-        base_cube : a pre-packed base cube to initialize the model with. If None, assumes ``torch.zeros``.
+        base_cube : a pre-packed base cube to initialize the model with. If 
+            None, assumes ``torch.zeros``.
 
     After the object is initialized, instance variables can be accessed, for example
 
@@ -22,9 +24,11 @@ class SimpleNet(torch.nn.Module):
     :ivar icube: the :class:`~mpol.images.ImageCube` instance
     :ivar fcube: the :class:`~mpol.fourier.FourierCube` instance
 
-    For example, you'll likely want to access the ``self.icube.sky_model`` at some point.
+    For example, you'll likely want to access the ``self.icube.sky_model`` 
+    at some point.
 
-    The idea is that :class:`~mpol.precomposed.SimpleNet` can save you some keystrokes composing models by connecting the most commonly used layers together.
+    The idea is that :class:`~mpol.precomposed.SimpleNet` can save you some keystrokes 
+    composing models by connecting the most commonly used layers together.
 
     .. mermaid:: _static/mmd/src/SimpleNet.mmd
 
@@ -59,7 +63,10 @@ class SimpleNet(torch.nn.Module):
 
     def forward(self):
         r"""
-        Feed forward to calculate the model visibilities. In this step, a :class:`~mpol.images.BaseCube` is fed to a :class:`~mpol.images.HannConvCube` is fed to a :class:`~mpol.images.ImageCube` is fed to a :class:`~mpol.fourier.FourierCube` to produce the visibility cube.
+        Feed forward to calculate the model visibilities. In this step, a 
+        :class:`~mpol.images.BaseCube` is fed to a :class:`~mpol.images.HannConvCube` 
+        is fed to a :class:`~mpol.images.ImageCube` is fed to a 
+        :class:`~mpol.fourier.FourierCube` to produce the visibility cube.
 
         Returns: 1D complex torch tensor of model visibilities.
         """

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -6,11 +6,12 @@ from mpol.losses import TSV, TV_image, entropy, nll_gridded, sparsity
 from mpol.plot import train_diagnostics_fig
 from mpol.utils import torch2npy
 
+
 def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):
     r"""
-    Train against a dirty image of the observed visibilities using a loss function 
-    of the mean squared error between the RML model image pixel fluxes and the 
-    dirty image pixel fluxes. Useful for initializing a separate RML optimization 
+    Train against a dirty image of the observed visibilities using a loss function
+    of the mean squared error between the RML model image pixel fluxes and the
+    dirty image pixel fluxes. Useful for initializing a separate RML optimization
     loop at a reasonable starting image.
 
     Parameters
@@ -20,7 +21,7 @@ def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):
     imager : :class:`mpol.gridding.DirtyImager` object
         Instance of the `mpol.gridding.DirtyImager` class.
     robust : float, default=0.5
-        Robust weighting parameter used to create a dirty image. 
+        Robust weighting parameter used to create a dirty image.
     learn_rate : float, default=100
         Learning rate for optimization loop
     niter : int, default=1000
@@ -29,14 +30,14 @@ def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):
     Returns
     -------
     model : `torch.nn.Module` object
-        The input `model` updated with the state of the training to the 
+        The input `model` updated with the state of the training to the
         dirty image
     """
     logging.info("    Initializing model to dirty image")
 
-    img, beam = imager.get_dirty_image(weighting="briggs",
-                                                robust=robust,
-                                                unit="Jy/arcsec^2")
+    img, beam = imager.get_dirty_image(
+        weighting="briggs", robust=robust, unit="Jy/arcsec^2"
+    )
     dirty_image = torch.tensor(img.copy())
     optimizer = torch.optim.SGD(model.parameters(), lr=learn_rate)
 
@@ -48,13 +49,13 @@ def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):
 
         sky_cube = model.icube.sky_cube
 
-        lossfunc = torch.nn.MSELoss(reduction="sum")  
+        lossfunc = torch.nn.MSELoss(reduction="sum")
         # MSELoss calculates mean squared error (squared L2 norm), so sqrt it
         loss = (lossfunc(sky_cube, dirty_image)) ** 0.5
         losses.append(loss.item())
 
         loss.backward()
-        optimizer.step()            
+        optimizer.step()
 
     return model
 
@@ -66,9 +67,9 @@ class TrainTest:
     Args:
         imager (:class:`mpol.gridding.DirtyImager` object): Instance of the `mpol.gridding.DirtyImager` class.
         optimizer (:class:`torch.optim` object): PyTorch optimizer class for the training loop.
-        scheduler (:class:`torch.optim.lr_scheduler` object, default=None): Scheduler for adjusting learning rate during optimization.        
+        scheduler (:class:`torch.optim.lr_scheduler` object, default=None): Scheduler for adjusting learning rate during optimization.
         regularizers (nested dict): Dictionary of image regularizers to use. For each, a dict of the strength ('lambda', float), whether to guess an initial value for lambda ('guess', bool), and other quantities needed to compute their loss term.
-            
+
             Example:
                 ``{"sparsity":{"lambda":1e-3, "guess":False},
                 "entropy": {"lambda":1e-3, "guess":True, "prior_intensity":1e-10}
@@ -78,23 +79,31 @@ class TrainTest:
         convergence_tol (float): Tolerance for training iteration stopping criterion as assessed by
             loss function (suggested <= 1e-3)
         train_diag_step (int): Interval at which training diagnostics are output. If None, no diagnostics will be generated.
-        kfold (int): The k-fold of the current training set (for diagnostics)        
+        kfold (int): The k-fold of the current training set (for diagnostics)
         save_prefix (str): Prefix (path) used for saved figure names. If None, figures won't be saved
         verbose (bool): Whether to print notification messages
     """
 
-    def __init__(self, imager, optimizer, scheduler=None, regularizers={},
-                epochs=10000, convergence_tol=1e-5,                 
-                train_diag_step=None, 
-                kfold=None, save_prefix=None, verbose=True
-                ): 
+    def __init__(
+        self,
+        imager,
+        optimizer,
+        scheduler=None,
+        regularizers={},
+        epochs=10000,
+        convergence_tol=1e-5,
+        train_diag_step=None,
+        kfold=None,
+        save_prefix=None,
+        verbose=True,
+    ):
         self._imager = imager
-        self._optimizer = optimizer      
+        self._optimizer = optimizer
         self._scheduler = scheduler
         self._regularizers = regularizers
         self._epochs = epochs
         self._convergence_tol = convergence_tol
-        
+
         self._train_diag_step = train_diag_step
         self._kfold = kfold
         self._save_prefix = save_prefix
@@ -128,7 +137,6 @@ class TrainTest:
             ratios <= 1 + self._convergence_tol
         )
 
-
     def loss_lambda_guess(self):
         r"""
         Set an initial guess for regularizer strengths :math:`\lambda_{x}` by
@@ -137,47 +145,48 @@ class TrainTest:
         The guesses update `lambda` values in `self._regularizers`.
         """
         if self._verbose:
-            logging.info("    Updating regularizer strengths with automated "
-                         f"guessing. Initial values: {self._regularizers}")
-            
+            logging.info(
+                "    Updating regularizer strengths with automated "
+                f"guessing. Initial values: {self._regularizers}"
+            )
+
         # generate images of the data using two briggs robust values
-        img1, _ = self._imager.get_dirty_image(weighting='briggs', robust=0.0)
-        img2, _ = self._imager.get_dirty_image(weighting='briggs', robust=0.5)
+        img1, _ = self._imager.get_dirty_image(weighting="briggs", robust=0.0)
+        img2, _ = self._imager.get_dirty_image(weighting="briggs", robust=0.5)
         img1 = torch.from_numpy(img1.copy())
         img2 = torch.from_numpy(img2.copy())
 
-        if self._regularizers.get('entropy', {}).get('guess') == True:
+        if self._regularizers.get("entropy", {}).get("guess") == True:
             # force negative pixel values to small positive value
             img1_nn = torch.where(img1 < 0, 1e-10, img1)
             img2_nn = torch.where(img2 < 0, 1e-10, img2)
 
-            loss_e1 = entropy(img1_nn, self._regularizers['entropy']['prior_intensity'])
-            loss_e2 = entropy(img2_nn, self._regularizers['entropy']['prior_intensity'])
+            loss_e1 = entropy(img1_nn, self._regularizers["entropy"]["prior_intensity"])
+            loss_e2 = entropy(img2_nn, self._regularizers["entropy"]["prior_intensity"])
             guess_e = 1 / (loss_e2 - loss_e1)
             # update stored value
-            self._regularizers['entropy']['lambda'] = guess_e.numpy().item()
+            self._regularizers["entropy"]["lambda"] = guess_e.numpy().item()
 
-        if self._regularizers.get('sparsity', {}).get('guess') == True:
+        if self._regularizers.get("sparsity", {}).get("guess") == True:
             loss_s1 = sparsity(img1)
             loss_s2 = sparsity(img2)
             guess_s = 1 / (loss_s2 - loss_s1)
-            self._regularizers['sparsity']['lambda'] = guess_s.numpy().item()
+            self._regularizers["sparsity"]["lambda"] = guess_s.numpy().item()
 
-        if self._regularizers.get('TV', {}).get('guess') == True:
-            loss_TV1 = TV_image(img1, self._regularizers['TV']['epsilon'])
-            loss_TV2 = TV_image(img2, self._regularizers['TV']['epsilon'])
+        if self._regularizers.get("TV", {}).get("guess") == True:
+            loss_TV1 = TV_image(img1, self._regularizers["TV"]["epsilon"])
+            loss_TV2 = TV_image(img2, self._regularizers["TV"]["epsilon"])
             guess_TV = 1 / (loss_TV2 - loss_TV1)
-            self._regularizers['TV']['lambda'] = guess_TV.numpy().item()
+            self._regularizers["TV"]["lambda"] = guess_TV.numpy().item()
 
-        if self._regularizers.get('TSV', {}).get('guess') == True:
+        if self._regularizers.get("TSV", {}).get("guess") == True:
             loss_TSV1 = TSV(img1)
             loss_TSV2 = TSV(img2)
             guess_TSV = 1 / (loss_TSV2 - loss_TSV1)
-            self._regularizers['TSV']['lambda'] = guess_TSV.numpy().item()
+            self._regularizers["TSV"]["lambda"] = guess_TSV.numpy().item()
 
         if self._verbose:
             logging.info(f"    Updated values: {self._regularizers}")
-                         
 
     def loss_eval(self, vis, dataset, sky_cube=None):
         r"""
@@ -200,19 +209,20 @@ class TrainTest:
 
         # regularizers
         if sky_cube is not None:
-            if self._regularizers.get('entropy', {}).get('lambda') is not None:
-                loss += self._regularizers['entropy']['lambda'] * entropy(
-                    sky_cube, self._regularizers['entropy']['prior_intensity'])
-            if self._regularizers.get('sparsity', {}).get('lambda') is not None:
-                loss += self._regularizers['sparsity']['lambda'] * sparsity(sky_cube)
-            if self._regularizers.get('TV', {}).get('lambda') is not None:
-                loss += self._regularizers['TV']['lambda'] * TV_image(
-                    sky_cube, self._regularizers['TV']['epsilon'])
-            if self._regularizers.get('TSV', {}).get('lambda') is not None:
-                loss += self._regularizers['TSV']['lambda'] * TSV(sky_cube)
+            if self._regularizers.get("entropy", {}).get("lambda") is not None:
+                loss += self._regularizers["entropy"]["lambda"] * entropy(
+                    sky_cube, self._regularizers["entropy"]["prior_intensity"]
+                )
+            if self._regularizers.get("sparsity", {}).get("lambda") is not None:
+                loss += self._regularizers["sparsity"]["lambda"] * sparsity(sky_cube)
+            if self._regularizers.get("TV", {}).get("lambda") is not None:
+                loss += self._regularizers["TV"]["lambda"] * TV_image(
+                    sky_cube, self._regularizers["TV"]["epsilon"]
+                )
+            if self._regularizers.get("TSV", {}).get("lambda") is not None:
+                loss += self._regularizers["TSV"]["lambda"] * TSV(sky_cube)
 
         return loss
-        
 
     def train(self, model, dataset):
         r"""
@@ -246,14 +256,14 @@ class TrainTest:
         old_mod_epoch = None
 
         run_loss_guess = False
-        for _,v in self._regularizers.items():
-             for i in v:
-                 if v[i] is True:
-                     run_loss_guess = True
+        for _, v in self._regularizers.items():
+            for i in v:
+                if v[i] is True:
+                    run_loss_guess = True
         if run_loss_guess:
             # guess initial strengths for regularizers in `self._regularizers`
             # that have 'guess':True
-            # (this updates `self._regularizers`) 
+            # (this updates `self._regularizers`)
             self.loss_lambda_guess()
 
         if self._verbose:
@@ -290,7 +300,7 @@ class TrainTest:
             sky_cube = model.icube.sky_cube
 
             # total flux in model image
-            total_flux = model.coords.cell_size ** 2 * torch.sum(sky_cube)
+            total_flux = model.coords.cell_size**2 * torch.sum(sky_cube)
             fluxes.append(torch2npy(total_flux))
 
             # calculate loss between model visibilities and data
@@ -305,17 +315,25 @@ class TrainTest:
 
             if self._scheduler is not None:
                 self._scheduler.step(loss)
-                learn_rates.append(self._optimizer.param_groups[0]['lr'])
+                learn_rates.append(self._optimizer.param_groups[0]["lr"])
 
             # generate optional fit diagnostics
-            if self._train_diag_step is not None and (count % self._train_diag_step == 0 or count == self._epochs or self.loss_convergence(np.array(losses))):
+            if self._train_diag_step is not None and (
+                count % self._train_diag_step == 0
+                or count == self._epochs
+                or self.loss_convergence(np.array(losses))
+            ):
                 train_fig, train_axes = train_diagnostics_fig(
-                    model, losses=losses, learn_rates=learn_rates, fluxes=fluxes,
+                    model,
+                    losses=losses,
+                    learn_rates=learn_rates,
+                    fluxes=fluxes,
                     old_model_image=old_mod_im,
                     old_model_epoch=old_mod_epoch,
-                    kfold=self._kfold, epoch=count,
-                    save_prefix=self._save_prefix
-                    )
+                    kfold=self._kfold,
+                    epoch=count,
+                    save_prefix=self._save_prefix,
+                )
                 self._train_figure = (train_fig, train_axes)
 
                 # temporarily store the current model image for use in next call to `train_diagnostics_fig`
@@ -326,15 +344,20 @@ class TrainTest:
 
         if self._verbose:
             if count < self._epochs:
-                logging.info("\n    Loss function convergence criterion met at epoch "
-                                "{}".format(count-1))
+                logging.info(
+                    "\n    Loss function convergence criterion met at epoch "
+                    "{}".format(count - 1)
+                )
             else:
-                logging.info("\n    Loss function convergence criterion not met; "
-                                "training stopped at specified maximum epochs, {}".format(self._epochs))
+                logging.info(
+                    "\n    Loss function convergence criterion not met; "
+                    "training stopped at specified maximum epochs, {}".format(
+                        self._epochs
+                    )
+                )
 
-        # return loss value    
+        # return loss value
         return loss.item(), losses
-
 
     def test(self, model, dataset):
         r"""
@@ -363,7 +386,6 @@ class TrainTest:
 
         # return loss value
         return loss.item()
-
 
     @property
     def regularizers(self):

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -12,13 +12,17 @@ def torch2npy(tensor):
 
 def ground_cube_to_packed_cube(ground_cube):
     r"""
-    Converts a Ground Cube to a Packed Visibility Cube for visibility-plane work. See Units and Conventions for more details.
+    Converts a Ground Cube to a Packed Visibility Cube for visibility-plane work. 
+    See Units and Conventions for more details.
 
     Args:
-        ground_cube: a previously initialized Ground Cube object (cube (3D torch tensor of shape ``(nchan, npix, npix)``))
+        ground_cube: a previously initialized Ground Cube object (cube (3D torch tensor 
+        of shape ``(nchan, npix, npix)``))
 
     Returns:
-        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting array after applying ``torch.fft.fftshift`` to the input arg; i.e Returns a Packed Visibility Cube.
+        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting 
+            array after applying ``torch.fft.fftshift`` to the input arg; i.e Returns a 
+            Packed Visibility Cube.
     """
     shifted = torch.fft.fftshift(ground_cube, dim=(1, 2))
     return shifted
@@ -26,13 +30,17 @@ def ground_cube_to_packed_cube(ground_cube):
 
 def packed_cube_to_ground_cube(packed_cube) -> torch.Tensor:
     r"""
-    Converts a Packed Visibility Cube to a Ground Cube for visibility-plane work. See Units and Conventions for more details.
+    Converts a Packed Visibility Cube to a Ground Cube for visibility-plane work. See 
+    Units and Conventions for more details.
 
     Args:
-        packed_cube: a previously initialized Packed Cube object (cube (3D torch tensor of shape ``(nchan, npix, npix)``))
+        packed_cube: a previously initialized Packed Cube object (cube (3D torch tensor 
+        of shape ``(nchan, npix, npix)``))
 
     Returns:
-        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting array after applying ``torch.fft.fftshift`` to the input arg; i.e Returns a Ground Cube.
+        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting 
+            array after applying ``torch.fft.fftshift`` to the input arg; i.e Returns a 
+            Ground Cube.
     """
     # fftshift the image cube to the correct quadrants
     shifted: torch.Tensor
@@ -42,13 +50,17 @@ def packed_cube_to_ground_cube(packed_cube) -> torch.Tensor:
 
 def sky_cube_to_packed_cube(sky_cube):
     r"""
-    Converts a Sky Cube to a Packed Image Cube for image-plane work. See Units and Conventions for more details.
+    Converts a Sky Cube to a Packed Image Cube for image-plane work. See Units and 
+    Conventions for more details.
 
     Args:
-        sky_cube: a previously initialized Sky Cube object with RA increasing to the *left* (cube (3D torch tensor of shape ``(nchan, npix, npix)``))
+        sky_cube: a previously initialized Sky Cube object with RA increasing to the 
+            *left* (cube (3D torch tensor of shape ``(nchan, npix, npix)``))
 
     Returns:
-        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting array after applying ``torch.fft.fftshift`` to the ``torch.flip()`` of the RA axis; i.e Returns a Packed Image Cube.
+        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting 
+            array after applying ``torch.fft.fftshift`` to the ``torch.flip()`` of the 
+            RA axis; i.e Returns a Packed Image Cube.
     """
     flipped = torch.flip(sky_cube, (2,))
     shifted = torch.fft.fftshift(flipped, dim=(1, 2))
@@ -57,13 +69,17 @@ def sky_cube_to_packed_cube(sky_cube):
 
 def packed_cube_to_sky_cube(packed_cube):
     r"""
-    Converts a Packed Image Cube to a Sky Cube for image-plane work. See Units and Conventions for more details.
+    Converts a Packed Image Cube to a Sky Cube for image-plane work. See Units and 
+    Conventions for more details.
 
     Args:
-        packed_cube: a previously initialized Packed Image Cube object (cube (3D torch tensor of shape ``(nchan, npix, npix)``))
+        packed_cube: a previously initialized Packed Image Cube object (cube (3D torch 
+        tensor of shape ``(nchan, npix, npix)``))
 
     Returns:
-        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting array after applying ``torch.fft.fftshift`` to the ``torch.flip()`` of the RA axis; i.e Returns a Sky Cube.
+        torch.double : 3D image cube of shape ``(nchan, npix, npix)``; The resulting 
+            array after applying ``torch.fft.fftshift`` to the ``torch.flip()`` of the 
+            RA axis; i.e Returns a Sky Cube.
     """
     # fftshift the image cube to the correct quadrants
     shifted = torch.fft.fftshift(packed_cube, dim=(1, 2))
@@ -74,7 +90,8 @@ def packed_cube_to_sky_cube(packed_cube):
 
 def get_Jy_arcsec2(T_b, nu=230e9):
     r"""
-    Calculate specific intensity from the brightness temperature, using the Rayleigh-Jeans definition.
+    Calculate specific intensity from the brightness temperature, using the 
+    Rayleigh-Jeans definition.
 
     Args:
         T_b : brightness temperature in [:math:`K`]
@@ -111,7 +128,10 @@ def log_stretch(x):
 
 def loglinspace(start, end, N_log, M_linear=3):
     r"""
-    Return a logspaced array of bin edges, with the first ``M_linear`` cells being equal width. There is a one-cell overlap between the linear and logarithmic stretches of the array, since the last linear cell is also the first logarithmic cell, which means the total number of cells is ``M_linear + N_log - 1``.
+    Return a logspaced array of bin edges, with the first ``M_linear`` cells being 
+    equal width. There is a one-cell overlap between the linear and logarithmic 
+    stretches of the array, since the last linear cell is also the first logarithmic 
+    cell, which means the total number of cells is ``M_linear + N_log - 1``.
 
     Args:
         start (float): starting cell left edge
@@ -138,7 +158,9 @@ def loglinspace(start, end, N_log, M_linear=3):
 
 
 def fftspace(width, N):
-    """Delivers a (nearly) symmetric coordinate array that spans :math:`N` elements (where :math:`N` is even) from `-width` to `+width`, but ensures that the middle point lands on :math:`0`. The array indices go from :math:`0` to :math:`N -1.`
+    """Delivers a (nearly) symmetric coordinate array that spans :math:`N` elements 
+    (where :math:`N` is even) from `-width` to `+width`, but ensures that the middle 
+    point lands on :math:`0`. The array indices go from :math:`0` to :math:`N -1.`
 
     Args:
         width (float): the width of the array
@@ -206,7 +228,8 @@ def convert_baselines(baselines, freq=None, wle=None):
     Returns:
         (1D array nvis): baselines in [klambda]
     Notes:
-        If ``baselines``, ``freq`` or ``wle`` are numpy arrays, their shapes must be broadcast-able.
+        If ``baselines``, ``freq`` or ``wle`` are numpy arrays, their shapes must be 
+        broadcast-able.
     """
     if (freq is None and wle is None) or (wle and freq):
         raise AttributeError("Exactly one of 'freq' or 'wle' must be supplied.")
@@ -250,7 +273,8 @@ def broadcast_and_convert_baselines(u, v, chan_freq):
 
 def get_max_spatial_freq(cell_size, npix):
     r"""
-    Calculate the maximum spatial frequency that the image can represent and still satisfy the Nyquist Sampling theorem.
+    Calculate the maximum spatial frequency that the image can represent and still 
+    satisfy the Nyquist Sampling theorem.
 
     Args:
         cell_size (float): the pixel size in arcseconds
@@ -269,10 +293,12 @@ def get_max_spatial_freq(cell_size, npix):
 
 def get_maximum_cell_size(uu_vv_point):
     r"""
-    Calculate the maximum possible cell_size that will still Nyquist sample the uu or vv point. Note: not q point.
+    Calculate the maximum possible cell_size that will still Nyquist sample the uu or 
+    vv point. Note: not q point.
 
     Args:
-        uu_vv_point (float): a single spatial frequency. Units of [:math:`\mathrm{k}\lambda`].
+        uu_vv_point (float): a single spatial frequency. Units of 
+            [:math:`\mathrm{k}\lambda`].
 
     Returns:
         cell_size (in arcsec)
@@ -331,7 +357,9 @@ def get_optimal_image_properties(image_width, u, v):
 
 def sky_gaussian_radians(l, m, a, delta_l, delta_m, sigma_l, sigma_m, Omega):
     r"""
-    Calculates a 2D Gaussian on the sky plane with inputs in radians. The Gaussian is centered at ``delta_l, delta_m``, has widths of ``sigma_l, sigma_m``, and is rotated ``Omega`` degrees East of North.
+    Calculates a 2D Gaussian on the sky plane with inputs in radians. The Gaussian is 
+    centered at ``delta_l, delta_m``, has widths of ``sigma_l, sigma_m``, and is 
+    rotated ``Omega`` degrees East of North.
 
     To evaluate the Gaussian, internally first we translate to center
 
@@ -380,7 +408,9 @@ def sky_gaussian_radians(l, m, a, delta_l, delta_m, sigma_l, sigma_m, Omega):
 
 def sky_gaussian_arcsec(x, y, a, delta_x, delta_y, sigma_x, sigma_y, Omega):
     r"""
-    Calculates a Gaussian on the sky plane using inputs in arcsec. This is a convenience wrapper to :func:`~mpol.utils.sky_gaussian_radians` that automatically converts from arcsec to radians.
+    Calculates a Gaussian on the sky plane using inputs in arcsec. This is a convenience
+    wrapper to :func:`~mpol.utils.sky_gaussian_radians` that automatically converts 
+    from arcsec to radians.
 
     Args:
         x: equivalent to l, but in units of [arcsec]
@@ -410,7 +440,12 @@ def sky_gaussian_arcsec(x, y, a, delta_x, delta_y, sigma_x, sigma_y, Omega):
 
 def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m, Omega):
     r"""
-    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in :func:`~mpol.utils.sky_gaussian_radians`, using analytical relationships. The Fourier Gaussian is parameterized using the sky plane centroid (``delta_l, delta_m``), widths (``sigma_l, sigma_m``) and rotation (``Omega``). Assumes that ``a`` was in units of :math:`\mathrm{Jy}/\mathrm{steradian}`.
+    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the 
+    Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in 
+    :func:`~mpol.utils.sky_gaussian_radians`, using analytical relationships. The 
+    Fourier Gaussian is parameterized using the sky plane centroid 
+    (``delta_l, delta_m``), widths (``sigma_l, sigma_m``) and rotation (``Omega``). 
+    Assumes that ``a`` was in units of :math:`\mathrm{Jy}/\mathrm{steradian}`.
 
     Args:
         u: l in units of [lambda]
@@ -425,9 +460,13 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
     Returns:
         2D Gaussian evaluated at input args
 
-    The following is a description of how we derived the analytical relationships. In what follows, all :math:`l` and :math:`m` coordinates are assumed to be in units of radians and all :math:`u` and :math:`v` coordinates are assumed to be in units of :math:`\lambda`.
+    The following is a description of how we derived the analytical relationships. In 
+    what follows, all :math:`l` and :math:`m` coordinates are assumed to be in units 
+    of radians and all :math:`u` and :math:`v` coordinates are assumed to be in units 
+    of :math:`\lambda`.
 
-    We start from Fourier dual relationships in Bracewell's `The Fourier Transform and Its Applications <https://ui.adsabs.harvard.edu/abs/2000fta..book.....B/abstract>`_
+    We start from Fourier dual relationships in Bracewell's `The Fourier Transform and 
+    Its Applications <https://ui.adsabs.harvard.edu/abs/2000fta..book.....B/abstract>`_
 
     .. math::
 
@@ -447,7 +486,9 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
 
     respectively. The sky-plane Gaussian has a maximum value of :math:`a`.
 
-    We will use the similarity, rotation, and shift theorems to turn :math:`f_0` into a form matching :math:`f_\mathrm{g}`, which simultaneously turns :math:`F_0` into :math:`F_\mathrm{g}(u,v)`.
+    We will use the similarity, rotation, and shift theorems to turn :math:`f_0` into 
+    a form matching :math:`f_\mathrm{g}`, which simultaneously turns :math:`F_0` into 
+    :math:`F_\mathrm{g}(u,v)`.
 
     The similarity theorem states that (in 1D)
 
@@ -461,7 +502,8 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
 
         f_1(l, m) = a \exp \left(-\frac{1}{2} \left [\left(\frac{l}{\sigma_l}\right)^2 + \left( \frac{m}{\sigma_m} \right)^2 \right] \right).
 
-    i.e., something we might call a normalized Gaussian function. Phrased in terms of :math:`f_0`, :math:`f_1` is
+    i.e., something we might call a normalized Gaussian function. Phrased in terms of 
+    :math:`f_0`, :math:`f_1` is
 
     .. math::
 
@@ -479,7 +521,9 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
 
         F_1(u, v) = a \sigma_l \sigma_m 2 \pi \exp \left ( -2 \pi^2 [\sigma_l^2 u^2 + \sigma_m^2 v^2] \right).
 
-    Next, we rotate the Gaussian to match the sky plane rotation. A rotation :math:`\Omega` in the sky plane is carried out in the same direction in the Fourier plane,
+    Next, we rotate the Gaussian to match the sky plane rotation. A rotation 
+    :math:`\Omega` in the sky plane is carried out in the same direction in the 
+    Fourier plane,
 
     .. math::
 
@@ -493,7 +537,9 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
         f_2(l, m) = f_1(l', m') \\
         F_2(u, v) = F_1(u', m')
 
-    Finally, we translate the sky plane Gaussian by amounts :math:`\delta_l`, :math:`\delta_m`, which corresponds to a phase shift in the Fourier plane Gaussian. The image plane translation is
+    Finally, we translate the sky plane Gaussian by amounts :math:`\delta_l`, 
+    :math:`\delta_m`, which corresponds to a phase shift in the Fourier plane Gaussian. 
+    The image plane translation is
 
     .. math::
 
@@ -511,7 +557,8 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
 
         F_\mathrm{g}(u,v) = a \sigma_l \sigma_m 2 \pi \exp \left ( -2 \pi^2 \left [\sigma_l^2 u'^2 + \sigma_m^2 v'^2 \right]  - 2 i \pi \left [\delta_l u + \delta_m v \right] \right).
 
-    N.B. that we have mixed primed (:math:`u'`) and unprimed (:math:`u`) coordinates in the same equation for brevity.
+    N.B. that we have mixed primed (:math:`u'`) and unprimed (:math:`u`) coordinates in 
+    the same equation for brevity.
 
     Finally, the same Fourier dual relationship holds
 
@@ -542,7 +589,12 @@ def fourier_gaussian_lambda_radians(u, v, a, delta_l, delta_m, sigma_l, sigma_m,
 
 def fourier_gaussian_klambda_arcsec(u, v, a, delta_x, delta_y, sigma_x, sigma_y, Omega):
     r"""
-    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in :func:`~mpol.utils.sky_gaussian_arcsec`, using analytical relationships. The Fourier Gaussian is parameterized using the sky plane centroid (``delta_l, delta_m``), widths (``sigma_l, sigma_m``) and rotation (``Omega``). Assumes that ``a`` was in units of :math:`\mathrm{Jy}/\mathrm{arcsec}^2`.
+    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the 
+    Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in 
+    :func:`~mpol.utils.sky_gaussian_arcsec`, using analytical relationships. The Fourier
+    Gaussian is parameterized using the sky plane centroid (``delta_l, delta_m``), 
+    widths (``sigma_l, sigma_m``) and rotation (``Omega``). Assumes that ``a`` was in 
+    units of :math:`\mathrm{Jy}/\mathrm{arcsec}^2`.
 
     Args:
         u: l in units of [klambda]


### PR DESCRIPTION
- Manually line wrapped many docstrings to conform to 88 characters per line or less. This wasn't a shortcoming of `napoleon` (or more accurately, the 'Google' string style I've been using) but actually `black`. I thought `black` would reflow docstrings by default, but actually that [doesn't seem to be the case](https://github.com/psf/black/issues/2865).

Should address the horizontal scrolling issue mentioned in #235 (also an issue for reading docstrings on GitHub).  With the reflowed lines, the 'Google' style and the 'NumPy' style actually look pretty similar. [Here](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html) is the official comparison with an admonition that a project should stick with a single docstyle. 

If we are going to stick to a recommended line length of 88 columns (black) for all `*.py` files, then NumPy style might have the slight edge in terms of readability, since most of our docstrings are long and have complex arg types like tensors. As long as the docs compile accurately this is a low priority issue, but worth thinking about which direction we want our docstrings to drift towards in the natural course of editing.

Side note that Sphinx, even the latest v7, is terrible at giving useful errors on docstring formatting. Most of the errors raised during the docs build did not correspond to the site listed, but rather some other non-indented docstring in the same file.