### PR TITLE
Stochastic Gradient Descent (SGD) example and functionality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,13 +65,9 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install .[test]
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: |
-          pip install flake8
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          ruff check .
       - name: Check types with MyPy
         run: |
           mypy src/mpol --pretty

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ runs
 
 # hatch-generated version file
 src/mpol/mpol_version.py
+
+.ruff_cache

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Contributors
 * Hannah Grzybowski, `@hgrzy`
 * Mary Ogborn
 * Tyler Quinn, `@trq5014`
+* Kristin Hopley

--- a/docs/_static/baselines/src/print_conversions.py
+++ b/docs/_static/baselines/src/print_conversions.py
@@ -1,3 +1,8 @@
+import csv
+
+import numpy as np
+from mpol.constants import c_ms
+
 import argparse
 
 parser = argparse.ArgumentParser(
@@ -6,11 +11,6 @@ parser = argparse.ArgumentParser(
 parser.add_argument("outfile", help="Destination to save CSV table.")
 args = parser.parse_args()
 
-import csv
-
-import numpy as np
-
-from mpol.constants import c_ms
 
 header = ["baseline", "100 GHz (Band 3)", "230 GHz (Band 6)", "340 GHz (Band 7)"]
 
@@ -20,18 +20,18 @@ frequencies = np.array([100, 230, 340]) * 1e9  # Hz
 
 def format_baseline(baseline_m):
     if baseline_m < 1e3:
-        return "{:.0f} m".format(baseline_m)
+        return f"{baseline_m:.0f} m"
     elif baseline_m < 1e6:
-        return "{:.0f} km".format(baseline_m * 1e-3)
+        return f"{baseline_m * 1e-3:.0f} km"
 
 
 def format_lambda(lam):
     if lam < 1e3:
-        return "{:.0f}".format(lam) + " :math:`\lambda`"
+        return f"{lam:.0f}" + r" :math:`\lambda`"
     elif lam < 1e6:
-        return "{:.0f}".format(lam * 1e-3) + " :math:`\mathrm{k}\lambda`"
+        return f"{lam * 1e-3:.0f}" + r" :math:`\mathrm{k}\lambda`"
     else:
-        return "{:.0f}".format(lam * 1e-6) + " :math:`\mathrm{M}\lambda`"
+        return f"{lam * 1e-6:.0f}" + r" :math:`\mathrm{M}\lambda`"
 
 
 data = []

--- a/docs/_static/fftshift/src/plot.py
+++ b/docs/_static/fftshift/src/plot.py
@@ -1,9 +1,3 @@
-import argparse
-
-parser = argparse.ArgumentParser(description="Create the fftshift plot")
-parser.add_argument("outfile", help="Destination to save plot.")
-args = parser.parse_args()
-
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.io import fits
@@ -11,8 +5,14 @@ from astropy.utils.data import download_file
 from matplotlib import patches
 from matplotlib.colors import LogNorm
 from matplotlib.gridspec import GridSpec
-
 from mpol import coordinates
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Create the fftshift plot")
+parser.add_argument("outfile", help="Destination to save plot.")
+args = parser.parse_args()
+
 
 fname = download_file(
     "https://zenodo.org/record/4711811/files/logo_cont.fits",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ## v0.3.0
 
+- Updated [MPoL-dev/examples](https://github.com/MPoL-dev/examples) with Stochastic Gradient Descent Example.
 - Standardized nomenclature of {class}`mpol.coordinates.GridCoords` and {class}`mpol.fourier.FourierCube` to use `sky_cube` for a normal image and `ground_cube` for a normal visibility cube (rather than `sky_` for visibility quantities). Routines use `packed_cube` instead of `cube` internally to be clear when packed format is preferred.
 - Modified {class}`mpol.coordinates.GridCoords` object to use cached properties [#187](https://github.com/MPoL-dev/MPoL/pull/187).
 - Changed the base spatial frequency unit from k$\lambda$ to $\lambda$, addressing [#223](https://github.com/MPoL-dev/MPoL/issues/223). This will affect most users data-reading routines!

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@
 
 ## v0.3.0
 
+- added {meth}`mpol.utils.convolve_packed_cube` method to convolve a 3D packed image cube with a 2D Gaussian. You can specify major axis, minor axis, and rotation angle.
+- added {meth}`mpol.utils.uv_gaussian_taper` to calculate a Gaussian tapering window in the visibility plane.
+- added the `vis_ext_Mlam` instance attribute to {class}`mpol.coordinates.GridCoords` for convenience plotting of visibility grids with axes labels in units of M$\lambda$.
 - Updated [MPoL-dev/examples](https://github.com/MPoL-dev/examples) with Stochastic Gradient Descent Example.
 - Standardized nomenclature of {class}`mpol.coordinates.GridCoords` and {class}`mpol.fourier.FourierCube` to use `sky_cube` for a normal image and `ground_cube` for a normal visibility cube (rather than `sky_` for visibility quantities). Routines use `packed_cube` instead of `cube` internally to be clear when packed format is preferred.
 - Modified {class}`mpol.coordinates.GridCoords` object to use cached properties [#187](https://github.com/MPoL-dev/MPoL/pull/187).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import os
 
 # -- Project information -----------------------------------------------------
 from pkg_resources import DistributionNotFound, get_distribution

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ myst_enable_extensions = ["dollarmath", "colon_fence", "amsmath"]
 autodoc_mock_imports = ["torch", "torchvision"]
 autodoc_member_order = "bysource"
 # https://github.com/sphinx-doc/sphinx/issues/9709
-# bug that if we set this here, we can't list individual members in the 
+# bug that if we set this here, we can't list individual members in the
 # actual API doc
 # autodoc_default_options = {"members": None}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dev = [
     "asdf",
     "pyro-ppl",
     "arviz[all]",
-    "visread>=0.0.4"
+    "visread>=0.0.4",
+    "ruff"
 ]
 test = [
     "pytest",
@@ -61,6 +62,7 @@ test = [
     "mypy",
     "visread>=0.0.4",
     "frank>=1.2.1",
+    "ruff"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dev = [
     "mypy",
     "frank>=1.2.1",
     "sphinx>=7.2.0",
-    "sphinx-autodoc2",
     "jupytext",
     "ipython!=8.7.0", # broken version for syntax higlight https://github.com/spatialaudio/nbsphinx/issues/687
     "nbsphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,16 @@ module = [
     "MPoL.utils"
     ]
 disallow_untyped_defs = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+select = ["F", "I", "E", "W", "YTT", "B", "Q", "PLE", "PLR", "PLW", "UP"]
+ignore = [
+    "E741",    # Allow ambiguous variable names
+    "PLR0911", # Allow many return statements
+    "PLR0913", # Allow many arguments to functions
+    "PLR0915", # Allow many statements
+    "PLR2004", # Allow magic numbers in comparisons
+]
+exclude = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,8 @@ disallow_untyped_defs = true
 [tool.ruff]
 target-version = "py310"
 line-length = 88
-select = ["F", "I", "E", "W", "YTT", "B", "Q", "PLE", "PLR", "PLW", "UP"]
+# will enable after sorting module locations
+# select = ["F", "I", "E", "W", "YTT", "B", "Q", "PLE", "PLR", "PLW", "UP"]
 ignore = [
     "E741",    # Allow ambiguous variable names
     "PLR0911", # Allow many return statements

--- a/src/mpol/__init__.py
+++ b/src/mpol/__init__.py
@@ -1,2 +1,1 @@
-from mpol.mpol_version import __version__
 zenodo_record = 10064221

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -79,6 +79,7 @@ class GridCoords:
     :ivar vis_ext: length-4 list of (left, right, bottom, top) expected by routines
         like ``matplotlib.pyplot.imshow`` in the ``extent`` parameter assuming
         ``origin='lower'``. Units of [:math:`\lambda`]
+    :ivar vis_ext_Mlam: like vis_ext, but in units of [:math:`\mathrm{M}\lambda`].
     """
 
     def __init__(self, cell_size: float, npix: int):
@@ -205,7 +206,11 @@ class GridCoords:
             self.u_bin_max,
             self.v_bin_min,
             self.v_bin_max,
-        ]  # [kλ]
+        ]  # [λ]
+    
+    @property
+    def vis_ext_Mlam(self) -> list[float]:
+        return [1e-6 * edge for edge in self.vis_ext]
 
     # --------------------------------------------------------------------------
     # Non-identical u & v properties

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from functools import cached_property
 
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -207,19 +207,17 @@ class GridCoords:
             self.v_bin_min,
             self.v_bin_max,
         ]  # [λ]
-    
+
     @property
     def vis_ext_Mlam(self) -> list[float]:
         return [1e-6 * edge for edge in self.vis_ext]
 
-    # --------------------------------------------------------------------------
-    # Non-identical u & v properties
-    # --------------------------------------------------------------------------
     @cached_property
     def ground_u_centers_2D(self) -> npt.NDArray[np.floating[Any]]:
         # only useful for plotting a sky_vis
         # uu increasing, no fftshift
-        # tile replicates the 1D u_centers array to a 2D array the size of the full UV grid
+        # tile replicates the 1D u_centers array to a 2D array the size of the full
+        # UV grid
         return np.tile(self.u_centers, (self.npix_u, 1))
 
     @cached_property
@@ -359,6 +357,6 @@ class GridCoords:
             # don't attempt to compare against different types
             return NotImplemented
 
-        # GridCoords objects are considered equal if they have the same cell_size and npix, since
-        # all other attributes are derived from these two core properties.
+        # GridCoords objects are considered equal if they have the same cell_size and
+        # npix, since all other attributes are derived from these two core properties.
         return bool(self.cell_size == other.cell_size and self.npix == other.npix)

--- a/src/mpol/coordinates.py
+++ b/src/mpol/coordinates.py
@@ -10,7 +10,7 @@ import torch
 
 import mpol.constants as const
 from mpol.exceptions import CellSizeError
-from mpol.utils import get_max_spatial_freq, get_maximum_cell_size
+from mpol.utils import get_maximum_cell_size
 
 
 class GridCoords:

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import logging
-from collections import defaultdict
 from typing import Any
 
 import numpy as np
@@ -11,11 +10,8 @@ from numpy import floating
 from numpy.typing import NDArray
 
 from mpol.datasets import Dartboard, GriddedDataset
-from mpol.precomposed import GriddedNet
 # from mpol.training import TrainTest, train_to_dirty_image
 # from mpol.training import TrainTest, train_to_dirty_image
-from mpol.plot import split_diagnostics_fig
-from mpol.utils import loglinspace
 
 
 # class CrossValidate:

--- a/src/mpol/crossval.py
+++ b/src/mpol/crossval.py
@@ -10,6 +10,7 @@ from numpy import floating
 from numpy.typing import NDArray
 
 from mpol.datasets import Dartboard, GriddedDataset
+
 # from mpol.training import TrainTest, train_to_dirty_image
 # from mpol.training import TrainTest, train_to_dirty_image
 
@@ -55,7 +56,8 @@ from mpol.datasets import Dartboard, GriddedDataset
 #         Number of k-folds to use in cross-validation
 #     split_method : str, default='dartboard'
 #         Method to split full dataset into train/test subsets
-#     dartboard_q_edges, dartboard_phi_edges : list of float, default=None, unit=[klambda]
+#     dartboard_q_edges, dartboard_phi_edges : list of float, default=None, 
+#   unit=[klambda]
 #         Radial and azimuthal bin edges of the cells used to split the dataset
 #         if `split_method`==`dartboard` (see `datasets.Dartboard`)
 #     split_diag_fig : bool, default=False

--- a/src/mpol/datasets.py
+++ b/src/mpol/datasets.py
@@ -7,9 +7,8 @@ import torch
 from numpy import floating, integer
 from numpy.typing import ArrayLike, NDArray
 
-from mpol.coordinates import GridCoords
-
 from mpol import utils
+from mpol.coordinates import GridCoords
 
 
 class GriddedDataset(torch.nn.Module):

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-
 import numpy as np
 import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
 import torchkbnufft
 from torch import nn
 
-from mpol.exceptions import DimensionMismatchError
-
 from mpol import utils
 from mpol.coordinates import GridCoords
+from mpol.exceptions import DimensionMismatchError
 
 
 class FourierCube(nn.Module):
@@ -437,10 +435,10 @@ class NuFFT(nn.Module):
 
 class NuFFTCached(NuFFT):
     r"""
-    This layer is similar to the :class:`mpol.fourier.NuFFT`, but provides extra 
+    This layer is similar to the :class:`mpol.fourier.NuFFT`, but provides extra
     functionality to cache the sparse matrices for a specific set of ``uu`` and ``vv``
-    points specified at initialization. 
-    
+    points specified at initialization.
+
     For repeated evaluations of this layer (as might exist within an optimization loop),
     ``sparse_matrices=True`` is likely to be the more accurate and faster choice. If
     ``sparse_matrices=False``, this routine will use the default table-based

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -44,7 +44,7 @@ class FourierCube(nn.Module):
         self.register_buffer("vis", None, persistent=persistent_vis)
         self.vis: torch.Tensor
 
-    def forward(self, cube: torch.Tensor) -> torch.Tensor:
+    def forward(self, packed_cube: torch.Tensor) -> torch.Tensor:
         """
         Perform the FFT of the image cube on each channel.
 
@@ -61,12 +61,12 @@ class FourierCube(nn.Module):
         """
 
         # make sure the cube is 3D
-        assert cube.dim() == 3, "cube must be 3D"
+        assert packed_cube.dim() == 3, "cube must be 3D"
 
         # the self.cell_size prefactor (in arcsec) is to obtain the correct output units
         # since it needs to correct for the spacing of the input grid.
         # See MPoL documentation and/or TMS Eqn A8.18 for more information.
-        self.vis = self.coords.cell_size**2 * torch.fft.fftn(cube, dim=(1, 2))
+        self.vis = self.coords.cell_size**2 * torch.fft.fftn(packed_cube, dim=(1, 2))
 
         return self.vis
 

--- a/src/mpol/fourier.py
+++ b/src/mpol/fourier.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
 
 import numpy as np
 import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
 import torchkbnufft
-from numpy.typing import NDArray
 from torch import nn
 
 from mpol.exceptions import DimensionMismatchError

--- a/src/mpol/geometry.py
+++ b/src/mpol/geometry.py
@@ -136,7 +136,7 @@ def observer_to_flat(
     # we don't know Z, but we can solve some equations to find that
     # y = Y / cos(i), as expected by intuition
     y1 = y2 / np.cos(incl)
-    
+
     # 3) inverse rotation about the z1 axis by an amount of omega
     cos_omega = np.cos(omega)
     sin_omega = np.sin(omega)

--- a/src/mpol/geometry.py
+++ b/src/mpol/geometry.py
@@ -16,8 +16,8 @@ def flat_to_observer(
     (X,Y,Z).
 
     It is assumed that the +Z axis points *towards* the observer. It is assumed that the
-      model is flat in the (x,y) frame (like a flat disk), and so the operations
-      involving ``z`` are neglected. But the model lives in 3D Cartesian space.
+    model is flat in the (x,y) frame (like a flat disk), and so the operations
+    involving ``z`` are neglected. But the model lives in 3D Cartesian space.
 
     In order,
 
@@ -28,11 +28,18 @@ def flat_to_observer(
     Inspired by `exoplanet/keplerian.py
     <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
 
+    Note that the (x,y) here are *not* the same as the `x_centers_2D` or `y_centers_2D`
+    attached to the :class:`mpol.coordinates.GridCoords` object. The (x,y) referred to
+    here are the 'perifocal frame' of the orbit, whereas the (X,Y,Z) are the sky or
+    observer frame. Typically, the sky observer frame is oriented such that X is North
+    (pointing up) and Y is East (pointing left). For more detail, see the `exoplanet
+    docs <https://docs.exoplanet.codes/en/latest/tutorials/data-and-models/#orbital-conventions>`_ or `Murray and Correia <https://ui.adsabs.harvard.edu/abs/2010exop.book...15M/abstract>`_.
+
     Parameters
     ----------
-    x : :class:`torch.Tensor` 
+    x : :class:`torch.Tensor`
         A tensor representing the x coordinate in the plane of the orbit.
-    y : :class:`torch.Tensor` 
+    y : :class:`torch.Tensor`
         A tensor representing the y coordinate in the plane of the orbit.
     omega : float
         Argument of periastron [radians]. Default 0.0.
@@ -43,7 +50,7 @@ def flat_to_observer(
 
     Returns
     -------
-    2-tuple of :class:`torch.Tensor` 
+    2-tuple of :class:`torch.Tensor`
         Two tensors representing ``(X, Y)`` in the observer frame.
     """
     # Rotation matrices result in a *clockwise* rotation of the axes,
@@ -98,11 +105,18 @@ def observer_to_flat(
     Inspired by `exoplanet/keplerian.py
     <https://github.com/exoplanet-dev/exoplanet/blob/main/src/exoplanet/orbits/keplerian.py>`_
 
+    Note that the (x,y) here are *not* the same as the `x_centers_2D` or `y_centers_2D`
+    attached to the :class:`mpol.coordinates.GridCoords` object. The (x,y) referred to
+    here are the 'perifocal frame' of the orbit, whereas the (X,Y,Z) are the sky or
+    observer frame. Typically, the sky observer frame is oriented such that X is North
+    (pointing up) and Y is East (pointing left). For more detail, see the `exoplanet
+    docs <https://docs.exoplanet.codes/en/latest/tutorials/data-and-models/#orbital-conventions>`_ or `Murray and Correia <https://ui.adsabs.harvard.edu/abs/2010exop.book...15M/abstract>`_.
+
     Parameters
     ----------
-    X : :class:`torch.Tensor` 
+    X : :class:`torch.Tensor`
         A tensor representing the x coordinate in the plane of the sky.
-    Y : :class:`torch.Tensor` 
+    Y : :class:`torch.Tensor`
         A tensor representing the y coordinate in the plane of the sky.
     omega : float
         A tensor representing an argument of periastron [radians] Default 0.0.
@@ -114,7 +128,7 @@ def observer_to_flat(
 
     Returns
     -------
-    2-tuple of :class:`torch.Tensor` 
+    2-tuple of :class:`torch.Tensor`
         Two tensors representing ``(x, y)`` in the flat frame.
     """
     # Rotation matrices result in a *clockwise* rotation of the axes,

--- a/src/mpol/geometry.py
+++ b/src/mpol/geometry.py
@@ -101,9 +101,9 @@ def observer_to_flat(
     Parameters
     ----------
     X : :class:`torch.Tensor` of :class:`torch.double`
-        A tensor representing the x coordinate in the plane of the orbit.
+        A tensor representing the x coordinate in the plane of the sky.
     Y : :class:`torch.Tensor` of :class:`torch.double`
-        A tensor representing the y coordinate in the plane of the orbit.
+        A tensor representing the y coordinate in the plane of the sky.
     omega : float
         A tensor representing an argument of periastron [radians] Default 0.0.
     incl : float

--- a/src/mpol/gridding.py
+++ b/src/mpol/gridding.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import warnings
-
-from typing import Any, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+import torch
 from fast_histogram import histogram as fast_hist
 
-import torch
-
-from mpol.coordinates import GridCoords
-from mpol.exceptions import DataError, ThresholdExceededError, WrongDimensionError
-from mpol.datasets import GriddedDataset
 from mpol import utils
+from mpol.coordinates import GridCoords
+from mpol.datasets import GriddedDataset
+from mpol.exceptions import DataError, ThresholdExceededError, WrongDimensionError
 
 
 def _check_data_inputs_2d(

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -1,14 +1,14 @@
-r"""The ``images`` module provides the core functionality of MPoL via 
+r"""The ``images`` module provides the core functionality of MPoL via
 :class:`mpol.images.ImageCube`."""
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 import numpy as np
 import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
 from torch import nn
-
-from typing import Callable
 
 from mpol import constants, utils
 from mpol.coordinates import GridCoords
@@ -114,14 +114,14 @@ class HannConvCube(nn.Module):
         \end{bmatrix}
 
     which is the 2D version of the discretely-sampled response function corresponding to
-    a Hann window, i.e., it is two 1D Hann windows multiplied together. This is a 
-    convolutional kernel in the image plane, and so effectively acts as apodization 
-    by a Hann window function in the Fourier domain. For more information, see the 
-    following Wikipedia articles on `Window Functions 
-    <https://en.wikipedia.org/wiki/Window_function>`_ in general and the `Hann Window 
+    a Hann window, i.e., it is two 1D Hann windows multiplied together. This is a
+    convolutional kernel in the image plane, and so effectively acts as apodization
+    by a Hann window function in the Fourier domain. For more information, see the
+    following Wikipedia articles on `Window Functions
+    <https://en.wikipedia.org/wiki/Window_function>`_ in general and the `Hann Window
     <https://en.wikipedia.org/wiki/Hann_function>`_ specifically.
 
-    The idea is that this layer would help naturally attenuate high spatial frequency 
+    The idea is that this layer would help naturally attenuate high spatial frequency
     artifacts by baking in a natural apodization in the Fourier plane.
 
     Args:

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -421,4 +421,5 @@ def convolve_packed_cube(
         torch.max(convolved_packed_cube.imag), thresh
     )
 
-    return convolved_packed_cube.real
+    r_cube: torch.Tensor = convolved_packed_cube.real
+    return r_cube

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -8,7 +8,7 @@ import torch
 import torch.fft  # to avoid conflicts with old torch.fft *function*
 from torch import nn
 
-from typing import Any, Callable
+from typing import Callable
 
 from mpol import constants, utils
 from mpol.coordinates import GridCoords

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -202,18 +202,98 @@ class GaussBaseBeam(nn.Module):
         the FWHH of the Gaussian
     """
 
+    def __init__(self, coords: GridCoords, FWHM: float) -> None:
+        super().__init__()
+
+        self.coords = coords
+        self.FWHM = FWHM
+
+        # convert FWHM to sigma and to radians
+        FWHM2sigma = 1 / (2 * np.sqrt(2 * np.log(2)))
+        sigma = self.FWHM * FWHM2sigma * constants.arcsec  # radians
+
+        # calculate the UV taper from the FWHM size.
+        u = self.coords.packed_u_centers_2D
+        v = self.coords.packed_v_centers_2D
+
+        taper_2D = np.exp(-2 * np.pi**2 * (sigma**2 * u**2 + sigma**2 * v**2))
+
+        # store taper to register so it transfers to GPU
+        self.register_buffer("taper_2D", torch.tensor(taper_2D, dtype=torch.float32))
+
+    def forward(self, packed_cube):
+        r"""
+        Convolve a packed_cube image with a 2D Gaussian PSF. Operation is carried out
+        in the Fourier domain using a Gaussian taper.
+
+        Parameters
+        ----------
+        packed_cube : :class:`torch.Tensor`  type
+            shape ``(nchan, npix, npix)`` image cube in packed format.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            The convolved cube in packed format.
+        """
+        nchan, npix_m, npix_l = packed_cube.size()
+        assert (
+            (npix_m == self.coords.npix) and (npix_l == self.coords.npix)
+        ), "packed_cube {:} does not have the same pixel dimensions as indicated by coords {:}".format(
+            packed_cube.size(), self.coords.npix
+        )
+
+        # in FFT packed format
+        # we're round-tripping, so we can ignore prefactors for correctness
+        # calling this `vis_like`, since it's not actually the vis
+        vis_like = torch.fft.fftn(packed_cube, dim=(1, 2))
+
+        # apply taper to packed image
+        tapered_vis = vis_like * torch.broadcast_to(self.taper_2D, packed_cube.size())
+
+        # iFFT back, ignoring prefactors for round-trip
+        convolved_packed_cube = torch.fft.ifftn(tapered_vis, dim=(1, 2))
+
+        # assert imaginaries are effectively zero, otherwise something went wrong
+        thresh = 1e-7
+        assert (
+            torch.max(convolved_packed_cube.imag) < thresh
+        ), "Round-tripped image contains max imaginary value {:} > {:} threshold, something may be amiss.".format(
+            torch.max(convolved_packed_cube.imag), thresh
+        )
+
+        r_cube: torch.Tensor = convolved_packed_cube.real
+        return r_cube
+
+
+class GaussBaseBeamTunable(nn.Module):
+    r"""
+    This layer will convolve the base cube with a Gaussian beam of variable resolution.
+    The FWHM of the beam (in arcsec) is a trainable parameter of the layer.
+
+    Parameters
+    ----------
+    coords : :class:`mpol.coordinates.GridCoords`
+        an object instantiated from the GridCoords class, containing information about
+        the image `cell_size` and `npix`.
+    """
+
     def __init__(self, coords: GridCoords) -> None:
         super().__init__()
-        
-        self.coords = coords 
-        
+
+        self.coords = coords
+
         self._FWHM_base = nn.Parameter(torch.tensor([-3.0]))
         self.softplus = nn.Softplus()
         # -3.0 corresponds to about 0.05 arcsec
 
         # store coordinates to register so they transfer to GPU
-        self.register_buffer("u", torch.tensor(self.coords.packed_u_centers_2D, dtype=torch.float32))
-        self.register_buffer("v", torch.tensor(self.coords.packed_v_centers_2D, dtype=torch.float32))
+        self.register_buffer(
+            "u", torch.tensor(self.coords.packed_u_centers_2D, dtype=torch.float32)
+        )
+        self.register_buffer(
+            "v", torch.tensor(self.coords.packed_v_centers_2D, dtype=torch.float32)
+        )
 
     @property
     def FWHM(self):
@@ -222,7 +302,7 @@ class GaussBaseBeam(nn.Module):
 
     def forward(self, packed_cube):
         r"""
-        Convolve a packed_cube image with a 2D Gaussian PSF. Operation is carried out 
+        Convolve a packed_cube image with a 2D Gaussian PSF. Operation is carried out
         in the Fourier domain using a Gaussian taper.
 
         Parameters
@@ -250,9 +330,11 @@ class GaussBaseBeam(nn.Module):
         # convert FWHM to sigma and to radians
         FWHM2sigma = 1 / (2 * np.sqrt(2 * np.log(2)))
         sigma = self.FWHM * FWHM2sigma * constants.arcsec  # radians
-    
+
         # calculate the UV taper from the FWHM size.
-        taper_2D = torch.exp(-2 * np.pi**2 * (sigma**2 * self.u**2 + sigma**2 * self.v**2))
+        taper_2D = torch.exp(
+            -2 * np.pi**2 * (sigma**2 * self.u**2 + sigma**2 * self.v**2)
+        )
 
         # apply taper to packed image
         tapered_vis = vis_like * torch.broadcast_to(taper_2D, packed_cube.size())

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -198,17 +198,14 @@ class GaussBaseBeam(nn.Module):
     coords : :class:`mpol.coordinates.GridCoords`
         an object instantiated from the GridCoords class, containing information about
         the image `cell_size` and `npix`.
-    nchan : int
-        the number of channels in the base cube. Default = 1.
     FWHM: float, units of arcsec
         the FWHH of the Gaussian
     """
 
-    def __init__(self, coords: GridCoords, nchan: int) -> None:
+    def __init__(self, coords: GridCoords) -> None:
         super().__init__()
         
         self.coords = coords 
-        self.nchan = nchan
         
         self._FWHM_base = nn.Parameter(torch.tensor([-3.0]))
         self.softplus = nn.Softplus()

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -238,7 +238,7 @@ class ImageCube(nn.Module):
 
         Returns
         -------
-        :class:`torch.Tensor`  type
+        :class:`torch.Tensor`
             tensor of shape ``(nchan, npix, npix)``), same as `cube`
         """
         self.packed_cube = packed_cube
@@ -337,6 +337,7 @@ def uv_gaussian_taper(
     Returns
     -------
     :class:`torch.Tensor` , shape ``(npix, npix)``
+        The Gaussian taper in packed format.
     """
 
     # convert FWHM to sigma and to radians
@@ -371,7 +372,7 @@ def convolve_packed_cube(
     coords: GridCoords,
     FWHM_maj: float,
     FWHM_min: float,
-    Omega: float,
+    Omega: float = 0,
 ) -> torch.Tensor:
     r"""
     Convolve an image cube with a 2D Gaussian PSF. Operation is carried out in the Fourier domain using a Gaussian taper.
@@ -392,6 +393,7 @@ def convolve_packed_cube(
     Returns
     -------
     :class:`torch.Tensor` 
+        The convolved cube in packed format.
     """
     nchan, npix_m, npix_l = packed_cube.size()
     assert (npix_m == coords.npix) and (

--- a/src/mpol/images.py
+++ b/src/mpol/images.py
@@ -60,8 +60,10 @@ class BaseCube(nn.Module):
 
         # The ``base_cube`` is already packed to make the Fourier transformation easier
         if base_cube is None:
+            # base_cube = -3 yields a nearly-blank cube after softplus, whereas
+            # base_cube = 0.0 yields a cube with avg value of ~0.7, which is too high
             self.base_cube = nn.Parameter(
-                torch.zeros(
+                -3 * torch.ones(
                     (self.nchan, self.coords.npix, self.coords.npix),
                     requires_grad=True,
                     dtype=torch.double,

--- a/src/mpol/input_output.py
+++ b/src/mpol/input_output.py
@@ -1,6 +1,6 @@
-import numpy as np 
-
+import numpy as np
 from astropy.io import fits
+
 
 class ProcessFitsImage:
     """
@@ -21,7 +21,7 @@ class ProcessFitsImage:
 
     def get_extent(self, header):
         """Get extent (in RA and Dec, units of [arcsec]) of image"""
-        
+
         # get the coordinate labels
         nx = header["NAXIS1"]
         ny = header["NAXIS2"]
@@ -55,7 +55,7 @@ class ProcessFitsImage:
 
 
     def get_beam(self, hdu_list, header):
-        """Get the major and minor widths [arcsec], and position angle, of a 
+        """Get the major and minor widths [arcsec], and position angle, of a
         clean beam"""
 
         if header.get("CASAMBM") is not None:
@@ -74,12 +74,12 @@ class ProcessFitsImage:
 
 
     def get_image(self, beam=True):
-        """Load a .fits image and return as a numpy array. Also return image 
+        """Load a .fits image and return as a numpy array. Also return image
         extent and optionally (`beam`) the clean beam dimensions"""
 
         hdu_list = fits.open(self._fits_file)
         hdu = hdu_list[0]
-        
+
         if len(hdu.data.shape) in [3, 4]:
             image = hdu.data[self._channel]  # first channel
         else:
@@ -98,4 +98,3 @@ class ProcessFitsImage:
             return image, ext, self.get_beam(hdu_list, header)
         else:
             return image, ext
-        

--- a/src/mpol/losses.py
+++ b/src/mpol/losses.py
@@ -1,9 +1,10 @@
+from typing import Optional
+
 import numpy as np
 import torch
 
 from mpol import constants
 from mpol.datasets import GriddedDataset
-from typing import Optional
 
 
 def _chi_squared(

--- a/src/mpol/onedim.py
+++ b/src/mpol/onedim.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from mpol.utils import torch2npy
 
 

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -1,15 +1,11 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as mco
-from matplotlib.patches import Ellipse
-import torch
 
 from astropy.visualization.mpl_normalize import simple_norm
 
-from mpol.gridding import DirtyImager
 from mpol.onedim import radialI, radialV
 from mpol.utils import loglinspace, torch2npy, packed_cube_to_sky_cube
-from mpol.input_output import ProcessFitsImage
 
 
 def get_image_cmap_norm(

--- a/src/mpol/plot.py
+++ b/src/mpol/plot.py
@@ -1,11 +1,10 @@
-import numpy as np
-import matplotlib.pyplot as plt
 import matplotlib.colors as mco
-
+import matplotlib.pyplot as plt
+import numpy as np
 from astropy.visualization.mpl_normalize import simple_norm
 
 from mpol.onedim import radialI, radialV
-from mpol.utils import loglinspace, torch2npy, packed_cube_to_sky_cube
+from mpol.utils import loglinspace, packed_cube_to_sky_cube, torch2npy
 
 
 def get_image_cmap_norm(
@@ -261,9 +260,9 @@ def vis_histogram_fig(
     else:
         supported_q = ["count", "weight", "vis_real", "vis_imag"]
         raise ValueError(
-            "`bin_quantity` ({}) must be one of "
-            "{}, or a user-provided numpy "
-            " array".format(bin_quantity, supported_q)
+            f"`bin_quantity` ({bin_quantity}) must be one of "
+            f"{supported_q}, or a user-provided numpy "
+            " array"
         )
 
     # buffer to include longest baselines in last bin
@@ -275,7 +274,7 @@ def vis_histogram_fig(
 
     bin_lab = None
     if all(np.diff(q_edges1d) == np.diff(q_edges1d)[0]):
-        bin_lab = r"Bin size {:.0f} k$\lambda$".format(np.diff(q_edges1d)[0])
+        bin_lab = rf"Bin size {np.diff(q_edges1d)[0]:.0f} k$\lambda$"
 
     # 2d histogram bins
     if q_edges is None:
@@ -887,7 +886,7 @@ def vis_1d_fig(
 
         # deproject the (u,v) points
         uu, vv, _ = deproject(uu, vv, geom["incl"], geom["Omega"])
-        
+
         # if the source is optically thick, rescale the deprojected V(q)
         if rescale_flux:
             V.real /= np.cos(geom["incl"] * np.pi / 180)
@@ -1004,7 +1003,7 @@ def radial_fig(
     channel=0,
     save_prefix=None,
 ):
-    """
+    r"""
     Figure for analysis of 1D (radial) brightness profile of MPoL model image,
     using a user-supplied geometry.
 
@@ -1079,7 +1078,7 @@ def radial_fig(
 
         # deproject the observed (u,v) points
         u, v, _ = deproject(u, v, geom["incl"], geom["Omega"])
-        
+
         # if the source is optically thick, rescale the deprojected V(q)
         if rescale_flux:
             V.real /= np.cos(geom["incl"] * np.pi / 180)

--- a/src/mpol/precomposed.py
+++ b/src/mpol/precomposed.py
@@ -1,11 +1,9 @@
+import typing
+
 import torch
 
+from mpol import fourier, images
 from mpol.coordinates import GridCoords
-
-from mpol import fourier
-from mpol import images
-
-import typing
 
 
 class GriddedNet(torch.nn.Module):
@@ -36,7 +34,7 @@ class GriddedNet(torch.nn.Module):
         a pre-packed base cube to initialize the model with. If
         None, assumes ``torch.zeros``.
 
-        
+
     After the object is initialized, instance variables can be accessed, for example
 
     :ivar bcube: the :class:`~mpol.images.BaseCube` instance
@@ -88,7 +86,7 @@ class GriddedNet(torch.nn.Module):
     def predict_loose_visibilities(
         self, uu: torch.Tensor, vv: torch.Tensor
     ) -> torch.Tensor:
-        """
+        r"""
         Use the :class:`mpol.fourier.NuFFT` to calculate loose model visibilities from
         the cube stored to ``self.icube.packed_cube``.
 

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -1,10 +1,6 @@
 import logging
-import numpy as np
 import torch
 
-from mpol.losses import TSV, TV_image, entropy, r_chi_squared_gridded, sparsity
-from mpol.plot import train_diagnostics_fig
-from mpol.utils import torch2npy
 
 
 def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):

--- a/src/mpol/training.py
+++ b/src/mpol/training.py
@@ -1,6 +1,6 @@
 import logging
-import torch
 
+import torch
 
 
 def train_to_dirty_image(model, imager, robust=0.5, learn_rate=100, niter=1000):

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -1,10 +1,10 @@
 import math
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 import torch
 
-from typing import Any
-import numpy.typing as npt
 from mpol.constants import arcsec, cc, deg, kB
 
 
@@ -221,10 +221,10 @@ def check_baselines(q, min_feasible_q=1e3, max_feasible_q=1e8):
 
     if max(q) > max_feasible_q:
         raise Warning(
-            "Maximum baseline of {:.1e} is > maximum expected "
-            "value of {:.1e}. Baselines must be in units of "
+            f"Maximum baseline of {max(q):.1e} is > maximum expected "
+            f"value of {max_feasible_q:.1e}. Baselines must be in units of "
             "[klambda], but it looks like they're in "
-            "[lambda].".format(max(q), max_feasible_q)
+            "[lambda]."
         )
 
     if min(q) > min_feasible_q * 1e3:
@@ -342,8 +342,8 @@ def sky_gaussian_radians(
     Omega: float,
 ) -> npt.NDArray[np.floating[Any]]:
     r"""
-    Calculates a 2D Gaussian on the sky plane with inputs in radians. The Gaussian is 
-    centered at ``delta_l, delta_m``, has widths of ``sigma_l, sigma_m``, and is 
+    Calculates a 2D Gaussian on the sky plane with inputs in radians. The Gaussian is
+    centered at ``delta_l, delta_m``, has widths of ``sigma_l, sigma_m``, and is
     rotated ``Omega`` degrees East of North.
 
     To evaluate the Gaussian, internally first we translate to center
@@ -364,8 +364,8 @@ def sky_gaussian_radians(
 
     .. math::
 
-        f_\mathrm{g}(l,m) = a \exp \left ( - \frac{1}{2} \left 
-        [ \left (\frac{l''}{\sigma_l} \right)^2 + \left( \frac{m''}{\sigma_m} 
+        f_\mathrm{g}(l,m) = a \exp \left ( - \frac{1}{2} \left
+        [ \left (\frac{l''}{\sigma_l} \right)^2 + \left( \frac{m''}{\sigma_m}
         \right )^2 \right ] \right )
 
     Args:
@@ -448,11 +448,11 @@ def fourier_gaussian_lambda_radians(
     Omega: float,
 ) -> npt.NDArray[np.floating[Any]]:
     r"""
-    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the 
-    Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in 
-    :func:`~mpol.utils.sky_gaussian_radians`, using analytical relationships. The 
-    Fourier Gaussian is parameterized using the sky plane centroid 
-    (``delta_l, delta_m``), widths (``sigma_l, sigma_m``) and rotation (``Omega``). 
+    Calculate the Fourier plane Gaussian :math:`F_\mathrm{g}(u,v)` corresponding to the
+    Sky plane Gaussian :math:`f_\mathrm{g}(l,m)` in
+    :func:`~mpol.utils.sky_gaussian_radians`, using analytical relationships. The
+    Fourier Gaussian is parameterized using the sky plane centroid
+    (``delta_l, delta_m``), widths (``sigma_l, sigma_m``) and rotation (``Omega``).
     Assumes that ``a`` was in units of :math:`\mathrm{Jy}/\mathrm{steradian}`.
 
     Args:
@@ -468,12 +468,12 @@ def fourier_gaussian_lambda_radians(
     Returns:
         2D Gaussian evaluated at input args
 
-    The following is a description of how we derived the analytical relationships. In 
-    what follows, all :math:`l` and :math:`m` coordinates are assumed to be in units 
-    of radians and all :math:`u` and :math:`v` coordinates are assumed to be in units 
+    The following is a description of how we derived the analytical relationships. In
+    what follows, all :math:`l` and :math:`m` coordinates are assumed to be in units
+    of radians and all :math:`u` and :math:`v` coordinates are assumed to be in units
     of :math:`\lambda`.
 
-    We start from Fourier dual relationships in Bracewell's `The Fourier Transform and 
+    We start from Fourier dual relationships in Bracewell's `The Fourier Transform and
     Its Applications <https://ui.adsabs.harvard.edu/abs/2000fta..book.....B/abstract>`_
 
     .. math::
@@ -494,8 +494,8 @@ def fourier_gaussian_lambda_radians(
 
     respectively. The sky-plane Gaussian has a maximum value of :math:`a`.
 
-    We will use the similarity, rotation, and shift theorems to turn :math:`f_0` into 
-    a form matching :math:`f_\mathrm{g}`, which simultaneously turns :math:`F_0` into 
+    We will use the similarity, rotation, and shift theorems to turn :math:`f_0` into
+    a form matching :math:`f_\mathrm{g}`, which simultaneously turns :math:`F_0` into
     :math:`F_\mathrm{g}(u,v)`.
 
     The similarity theorem states that (in 1D)
@@ -511,30 +511,30 @@ def fourier_gaussian_lambda_radians(
         f_1(l, m) = a \exp \left(-\frac{1}{2} \left [\left(\frac{l}{\sigma_l}\right)^2 +
         \left( \frac{m}{\sigma_m} \right)^2 \right] \right).
 
-    i.e., something we might call a normalized Gaussian function. Phrased in terms of 
+    i.e., something we might call a normalized Gaussian function. Phrased in terms of
     :math:`f_0`, :math:`f_1` is
 
     .. math::
 
-        f_1(l, m) = f_0\left ( \frac{l}{\sigma_l \sqrt{2 \pi}},\, 
+        f_1(l, m) = f_0\left ( \frac{l}{\sigma_l \sqrt{2 \pi}},\,
         \frac{m}{\sigma_m \sqrt{2 \pi}}\right).
 
     Therefore, according to the similarity theorem, the equivalent :math:`F_1(u,v)` is
 
     .. math::
 
-        F_1(u, v) = \sigma_l \sigma_m 2 \pi F_0 \left( \sigma_l \sqrt{2 \pi} u,\, 
+        F_1(u, v) = \sigma_l \sigma_m 2 \pi F_0 \left( \sigma_l \sqrt{2 \pi} u,\,
         \sigma_m \sqrt{2 \pi} v \right),
 
     or
 
     .. math::
 
-        F_1(u, v) = a \sigma_l \sigma_m 2 \pi \exp \left ( -2 \pi^2 [\sigma_l^2 u^2 + 
+        F_1(u, v) = a \sigma_l \sigma_m 2 \pi \exp \left ( -2 \pi^2 [\sigma_l^2 u^2 +
         \sigma_m^2 v^2] \right).
 
-    Next, we rotate the Gaussian to match the sky plane rotation. A rotation 
-    :math:`\Omega` in the sky plane is carried out in the same direction in the 
+    Next, we rotate the Gaussian to match the sky plane rotation. A rotation
+    :math:`\Omega` in the sky plane is carried out in the same direction in the
     Fourier plane,
 
     .. math::
@@ -549,8 +549,8 @@ def fourier_gaussian_lambda_radians(
         f_2(l, m) = f_1(l', m') \\
         F_2(u, v) = F_1(u', m')
 
-    Finally, we translate the sky plane Gaussian by amounts :math:`\delta_l`, 
-    :math:`\delta_m`, which corresponds to a phase shift in the Fourier plane Gaussian. 
+    Finally, we translate the sky plane Gaussian by amounts :math:`\delta_l`,
+    :math:`\delta_m`, which corresponds to a phase shift in the Fourier plane Gaussian.
     The image plane translation is
 
     .. math::
@@ -563,16 +563,16 @@ def fourier_gaussian_lambda_radians(
 
         F_3(u,v) = \exp\left (- 2 i \pi [\delta_l u + \delta_m v] \right) F_2(u,v)
 
-    We have arrived at the corresponding Fourier Gaussian, :math:`F_\mathrm{g}(u,v) = 
+    We have arrived at the corresponding Fourier Gaussian, :math:`F_\mathrm{g}(u,v) =
     F_3(u,v)`. The simplified equation is
 
     .. math::
 
-        F_\mathrm{g}(u,v) = a \sigma_l \sigma_m 2 \pi \exp \left ( 
-        -2 \pi^2 \left [\sigma_l^2 u'^2 + \sigma_m^2 v'^2 \right]  
+        F_\mathrm{g}(u,v) = a \sigma_l \sigma_m 2 \pi \exp \left (
+        -2 \pi^2 \left [\sigma_l^2 u'^2 + \sigma_m^2 v'^2 \right]
         - 2 i \pi \left [\delta_l u + \delta_m v \right] \right).
 
-    N.B. that we have mixed primed (:math:`u'`) and unprimed (:math:`u`) coordinates in 
+    N.B. that we have mixed primed (:math:`u'`) and unprimed (:math:`u`) coordinates in
     the same equation for brevity.
 
     Finally, the same Fourier dual relationship holds

--- a/src/mpol/utils.py
+++ b/src/mpol/utils.py
@@ -375,7 +375,7 @@ def sky_gaussian_radians(
         delta_l : offset [radians]
         delta_m : offset [radians]
         sigma_l : width [radians]
-        sigma_M : width [radians]
+        sigma_m : width [radians]
         Omega : position angle of ascending node [degrees] east of north.
 
     Returns:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -198,7 +198,6 @@ def mock_1d_vis_model(mock_1d_archive):
     geom = m["geometry"]
     geom = geom[()]
 
-    Vtrue = m["vis"]
     Vtrue_dep = m["vis_dep"]
     q_dep = m["baselines_dep"]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,13 @@ def img2D_butterfly():
 
     return img
 
+@pytest.fixture(scope="session")
+def sky_cube(img2D_butterfly):
+    """Create a sky tensor image cube from the butterfly."""
+    print("npix packed cube", img2D_butterfly.shape)
+    # tile to some nchan, npix, npix
+    sky_cube = torch.tile(torch.from_numpy(img2D_butterfly), (_nchan, 1, 1))
+    return sky_cube
 
 @pytest.fixture(scope="session")
 def packed_cube(img2D_butterfly):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,13 +1,12 @@
+from importlib.resources import files
+
 import numpy as np
 import pytest
 import torch
 import visread.process
 from astropy.utils.data import download_file
-
 from mpol import coordinates, fourier, gridding, images, utils
 from mpol.__init__ import zenodo_record
-
-from importlib.resources import files
 
 # private variables to this module
 _npz_path = files("mpol.data").joinpath("mock_data.npz")

--- a/test/coordinates_test.py
+++ b/test/coordinates_test.py
@@ -1,9 +1,9 @@
 import matplotlib.pyplot as plt
 import torch
 import pytest
+import numpy as np
 
-from mpol import coordinates
-from mpol.constants import *
+from mpol import coordinates, constants
 from mpol.exceptions import CellSizeError
 
 
@@ -117,7 +117,7 @@ def test_tile_vs_meshgrid_implementation():
     coords = coordinates.GridCoords(cell_size=0.05, npix=800)
 
     x_centers_2d, y_centers_2d = np.meshgrid(
-        coords.l_centers / arcsec, coords.m_centers / arcsec, indexing="xy"
+        coords.l_centers / constants.arcsec, coords.m_centers / constants.arcsec, indexing="xy"
     )
 
     ground_u_centers_2D, ground_v_centers_2D = np.meshgrid(

--- a/test/coordinates_test.py
+++ b/test/coordinates_test.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
-import torch
-import pytest
 import numpy as np
-
-from mpol import coordinates, constants
+import pytest
+import torch
+from mpol import constants, coordinates
 from mpol.exceptions import CellSizeError
 
 
@@ -47,7 +46,7 @@ def test_grid_coords_plot_2D_uvq_sky(tmp_path):
     im = ax[2].imshow(coords.ground_q_centers_2D, **ikw)
     plt.colorbar(im, ax=ax[2])
 
-    for a, t in zip(ax, ["u", "v", "q"]):
+    for a, t in zip(ax, ["u", "v", "q"], strict=False):
         a.set_title(t)
 
     fig.savefig(tmp_path / "sky_uvq.png", dpi=300)
@@ -68,7 +67,7 @@ def test_grid_coords_plot_2D_uvq_packed(tmp_path):
     im = ax[2].imshow(coords.packed_q_centers_2D, **ikw)
     plt.colorbar(im, ax=ax[2])
 
-    for a, t in zip(ax, ["u", "v", "q"]):
+    for a, t in zip(ax, ["u", "v", "q"], strict=False):
         a.set_title(t)
 
     fig.savefig(tmp_path / "packed_uvq.png", dpi=300)

--- a/test/crossval_test.py
+++ b/test/crossval_test.py
@@ -2,12 +2,10 @@ import copy
 
 import matplotlib.pyplot as plt
 import numpy as np
-import torch
 
 # from mpol.crossval import CrossValidate, DartboardSplitGridded, RandomCellSplitGridded
 from mpol.crossval import DartboardSplitGridded, RandomCellSplitGridded
 from mpol.datasets import Dartboard
-from mpol.plot import split_diagnostics_fig
 
 
 # def test_crossvalclass_split_dartboard(coords, imager, dataset, generic_parameters):

--- a/test/crossval_test.py
+++ b/test/crossval_test.py
@@ -7,7 +7,6 @@ import numpy as np
 from mpol.crossval import DartboardSplitGridded, RandomCellSplitGridded
 from mpol.datasets import Dartboard
 
-
 # def test_crossvalclass_split_dartboard(coords, imager, dataset, generic_parameters):
 #     # using the CrossValidate class, split a dataset into train/test subsets
 #     # using 'dartboard' splitter

--- a/test/datasets_test.py
+++ b/test/datasets_test.py
@@ -4,7 +4,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-
 from mpol import datasets, fourier, images
 
 

--- a/test/fftshift_test.py
+++ b/test/fftshift_test.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
-import mpol.utils
 
 
 def test_mpol_fftshift(tmp_path):

--- a/test/fftshift_test.py
+++ b/test/fftshift_test.py
@@ -3,7 +3,6 @@ import numpy as np
 import torch
 
 
-
 def test_mpol_fftshift(tmp_path):
 
     # create a fake image

--- a/test/fourier_test.py
+++ b/test/fourier_test.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from pytest import approx
-
 from mpol import fourier, images, utils
+from pytest import approx
 
 
 def test_fourier_cube(coords, tmp_path):

--- a/test/fourier_test.py
+++ b/test/fourier_test.py
@@ -188,10 +188,7 @@ def test_predict_vis_nufft_cached(coords, baselines_1D):
 def test_nufft_cached_predict_GPU(coords, baselines_1D):
     if torch.cuda.is_available():
         device = torch.device("cuda")
-    elif torch.backends.mps.is_available():
-        device = torch.device("mps")
     else:
-        device = torch.device("cpu")
         return
 
     # just see that we can load the layer and get something through without error

--- a/test/geometry_test.py
+++ b/test/geometry_test.py
@@ -1,13 +1,13 @@
+import numpy as np
 import torch
-from pytest import approx
-import numpy as np 
-
 from mpol import geometry
+from pytest import approx
+
 
 def test_rotate_points():
-    '''
+    """
     Test rotation from flat 2D frame to observer frame and back
-    '''
+    """
     xs = torch.tensor([0.0, 1.0, 2.0])
     ys = torch.tensor([1.0, -1.0, 2.0])
 
@@ -29,14 +29,13 @@ def test_rotate_points():
 
 
 def test_rotate_coords(coords):
-    
+
     omega = 35. * np.pi/180
     incl = 30. * np.pi/180
     Omega = 210. * np.pi/180
 
     x, y = geometry.observer_to_flat(coords.sky_x_centers_2D, coords.sky_y_centers_2D, omega=omega, incl=incl, Omega=Omega)
-    
+
     print(x, y)
 
-    
-    
+

--- a/test/gridder_dataset_export_test.py
+++ b/test/gridder_dataset_export_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from mpol import coordinates, gridding
 
 

--- a/test/gridder_dataset_export_test.py
+++ b/test/gridder_dataset_export_test.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from mpol import coordinates, gridding
-from mpol.constants import *
 
 
 def test_cell_variance_error_pytorch(mock_dataset_np):

--- a/test/gridder_gridding_test.py
+++ b/test/gridder_gridding_test.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 
 from mpol import coordinates, gridding
-from mpol.constants import *
 
 
 def test_average_cont(coords, mock_dataset_np):

--- a/test/gridder_gridding_test.py
+++ b/test/gridder_gridding_test.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
 from mpol import coordinates, gridding
 
 

--- a/test/gridder_imager_test.py
+++ b/test/gridder_imager_test.py
@@ -4,8 +4,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
 from mpol import coordinates, gridding
+
 
 # cache an instantiated imager for future imaging ops
 @pytest.fixture
@@ -139,7 +139,7 @@ def test_grid_uniform(imager, tmp_path):
     ax[1, 0].imshow(img_uniform[chan], **kw)
 
     ax[0, 1].imshow(beam_robust[chan], **kw)
-    ax[0, 1].set_title("robust={:}".format(r))
+    ax[0, 1].set_title(f"robust={r}")
     ax[1, 1].imshow(img_robust[chan], **kw)
 
     # the differences
@@ -181,7 +181,7 @@ def test_grid_uniform_arcsec2(imager, tmp_path):
     plt.colorbar(im, ax=ax[1, 0])
 
     ax[0, 1].imshow(beam_robust[chan], **kw)
-    ax[0, 1].set_title("robust={:}".format(r))
+    ax[0, 1].set_title(f"robust={r}")
     im = ax[1, 1].imshow(img_robust[chan], **kw)
     plt.colorbar(im, ax=ax[1, 1])
 
@@ -223,7 +223,7 @@ def test_grid_natural(imager, tmp_path):
     ax[1, 0].imshow(img_natural[chan], **kw)
 
     ax[0, 1].imshow(beam_robust[chan], **kw)
-    ax[0, 1].set_title("robust={:}".format(r))
+    ax[0, 1].set_title(f"robust={r}")
     ax[1, 1].imshow(img_robust[chan], **kw)
 
     # the differences
@@ -265,7 +265,7 @@ def test_grid_natural_arcsec2(imager, tmp_path):
     plt.colorbar(im, ax=ax[1, 0])
 
     ax[0, 1].imshow(beam_robust[chan], **kw)
-    ax[0, 1].set_title("robust={:}".format(r))
+    ax[0, 1].set_title(f"robust={r}")
     im = ax[1, 1].imshow(img_robust[chan], **kw)
     plt.colorbar(im, ax=ax[1, 1])
 

--- a/test/gridder_imager_test.py
+++ b/test/gridder_imager_test.py
@@ -6,8 +6,6 @@ import numpy as np
 import pytest
 
 from mpol import coordinates, gridding
-from mpol.constants import *
-
 
 # cache an instantiated imager for future imaging ops
 @pytest.fixture

--- a/test/gridder_init_test.py
+++ b/test/gridder_init_test.py
@@ -1,6 +1,5 @@
-import pytest
-
 import numpy as np
+import pytest
 from mpol import coordinates, gridding
 from mpol.exceptions import CellSizeError, DataError
 

--- a/test/gridder_init_test.py
+++ b/test/gridder_init_test.py
@@ -1,7 +1,7 @@
 import pytest
 
+import numpy as np
 from mpol import coordinates, gridding
-from mpol.constants import *
 from mpol.exceptions import CellSizeError, DataError
 
 

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -205,7 +205,11 @@ def test_taper(coords, tmp_path):
 
         norm = plot.get_image_cmap_norm(taper_2D, symmetric=True)
         im = ax.imshow(
-            taper_2D, extent=coords.vis_ext_Mlam, origin="lower", cmap="bwr_r", norm=norm
+            taper_2D,
+            extent=coords.vis_ext_Mlam,
+            origin="lower",
+            cmap="bwr_r",
+            norm=norm,
         )
         plt.colorbar(im, ax=ax)
 
@@ -240,5 +244,37 @@ def test_convolve(packed_cube, coords, tmp_path):
 
         plt.colorbar(im, ax=ax[1])
         fig.savefig(tmp_path / "convolved_{:.2f}.png".format(r), dpi=300)
+
+    plt.close("all")
+
+
+def test_convolve_rotate(packed_cube, coords, tmp_path):
+    # show only the first channel
+    chan = 0
+
+    r_max = 0.2
+    r_min = 0.1 
+    for Omega in np.arange(0.0, 180, step=20):
+        fig, ax = plt.subplots(ncols=2)
+        # put back to sky
+        sky_cube = utils.packed_cube_to_sky_cube(packed_cube)
+        im = ax[0].imshow(
+            sky_cube[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
+        )
+        flux = coords.cell_size**2 * torch.sum(sky_cube[chan])
+        ax[0].set_title("tot flux: {:.3f} Jy".format(flux))
+        plt.colorbar(im, ax=ax[0])
+
+        c = images.convolve_packed_cube(packed_cube, coords, r_max, r_min, Omega)
+        # put back to sky
+        c_sky = utils.packed_cube_to_sky_cube(c)
+        im = ax[1].imshow(
+            c_sky[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
+        )
+        flux = coords.cell_size**2 * torch.sum(c_sky[chan])
+        ax[1].set_title("tot flux: {:.3f} Jy".format(flux))
+
+        plt.colorbar(im, ax=ax[1])
+        fig.savefig(tmp_path / "convolved_Omega_{:.0f}.png".format(Omega), dpi=300)
 
     plt.close("all")

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -1,9 +1,8 @@
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 import torch
 from astropy.io import fits
-import numpy as np
-
 from mpol import coordinates, images, plot, utils
 
 
@@ -213,7 +212,7 @@ def test_taper(coords, tmp_path):
         )
         plt.colorbar(im, ax=ax)
 
-        fig.savefig(tmp_path / "taper{:.2f}.png".format(r), dpi=300)
+        fig.savefig(tmp_path / f"taper{r:.2f}.png", dpi=300)
 
     plt.close("all")
 
@@ -230,7 +229,7 @@ def test_convolve(packed_cube, coords, tmp_path):
             sky_cube[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
         )
         flux = coords.cell_size**2 * torch.sum(sky_cube[chan])
-        ax[0].set_title("tot flux: {:.3f} Jy".format(flux))
+        ax[0].set_title(f"tot flux: {flux:.3f} Jy")
         plt.colorbar(im, ax=ax[0])
 
         c = images.convolve_packed_cube(packed_cube, coords, r, r, 0.0)
@@ -240,10 +239,10 @@ def test_convolve(packed_cube, coords, tmp_path):
             c_sky[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
         )
         flux = coords.cell_size**2 * torch.sum(c_sky[chan])
-        ax[1].set_title("tot flux: {:.3f} Jy".format(flux))
+        ax[1].set_title(f"tot flux: {flux:.3f} Jy")
 
         plt.colorbar(im, ax=ax[1])
-        fig.savefig(tmp_path / "convolved_{:.2f}.png".format(r), dpi=300)
+        fig.savefig(tmp_path / f"convolved_{r:.2f}.png", dpi=300)
 
     plt.close("all")
 
@@ -253,7 +252,7 @@ def test_convolve_rotate(packed_cube, coords, tmp_path):
     chan = 0
 
     r_max = 0.2
-    r_min = 0.1 
+    r_min = 0.1
     for Omega in np.arange(0.0, 180, step=20):
         fig, ax = plt.subplots(ncols=2)
         # put back to sky
@@ -262,7 +261,7 @@ def test_convolve_rotate(packed_cube, coords, tmp_path):
             sky_cube[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
         )
         flux = coords.cell_size**2 * torch.sum(sky_cube[chan])
-        ax[0].set_title("tot flux: {:.3f} Jy".format(flux))
+        ax[0].set_title(f"tot flux: {flux:.3f} Jy")
         plt.colorbar(im, ax=ax[0])
 
         c = images.convolve_packed_cube(packed_cube, coords, r_max, r_min, Omega)
@@ -272,9 +271,9 @@ def test_convolve_rotate(packed_cube, coords, tmp_path):
             c_sky[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
         )
         flux = coords.cell_size**2 * torch.sum(c_sky[chan])
-        ax[1].set_title("tot flux: {:.3f} Jy".format(flux))
+        ax[1].set_title(f"tot flux: {flux:.3f} Jy")
 
         plt.colorbar(im, ax=ax[1])
-        fig.savefig(tmp_path / "convolved_Omega_{:.0f}.png".format(Omega), dpi=300)
+        fig.savefig(tmp_path / f"convolved_Omega_{Omega:.0f}.png", dpi=300)
 
     plt.close("all")

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -304,9 +304,7 @@ def test_GaussConvCube_rotate(sky_cube, coords, tmp_path):
 def test_GaussBaseBeam(packed_cube, coords, tmp_path):
     # show only the first channel
     chan = 0
-    nchan = packed_cube.size()[0]
-
-    layer = images.GaussBaseBeam(coords, nchan)
+    layer = images.GaussBaseBeam(coords)
 
     for FWHM_base in np.linspace(-4, 0.5, num=10):
         fig, ax = plt.subplots(ncols=2)

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -2,9 +2,9 @@ import matplotlib.pyplot as plt
 import pytest
 import torch
 from astropy.io import fits
+import numpy as np
 
 from mpol import coordinates, images, plot, utils
-from mpol.constants import *
 
 
 def test_single_chan():

--- a/test/images_test.py
+++ b/test/images_test.py
@@ -302,9 +302,43 @@ def test_GaussConvCube_rotate(sky_cube, coords, tmp_path):
     plt.close("all")
 
 def test_GaussBaseBeam(packed_cube, coords, tmp_path):
+    chan = 0
+
+    for FWHM in np.linspace(0.02, 0.5, num=10):
+        fig, ax = plt.subplots(ncols=2)
+        # put back to sky
+        sky_cube = utils.packed_cube_to_sky_cube(packed_cube)
+        im = ax[0].imshow(
+            sky_cube[chan], extent=coords.img_ext, origin="lower", cmap="inferno"
+        )
+        flux = coords.cell_size**2 * torch.sum(sky_cube[chan])
+        ax[0].set_title(f"tot flux: {flux:.3f} Jy")
+        plt.colorbar(im, ax=ax[0])
+
+        # set base resolution
+        layer = images.GaussBaseBeam(coords, FWHM)
+        c = layer(packed_cube)
+        # put back to sky
+        c_sky = utils.packed_cube_to_sky_cube(c)
+        flux = coords.cell_size**2 * torch.sum(c_sky[chan])
+        im = ax[1].imshow(
+            c_sky[chan].detach().numpy(),
+            extent=coords.img_ext,
+            origin="lower",
+            cmap="inferno",
+        )
+        ax[1].set_title(f"tot flux: {flux:.3f} Jy")
+
+        plt.colorbar(im, ax=ax[1])
+        fig.savefig(tmp_path / "convolved_FWHM_{:.2f}.png".format(layer.FWHM), dpi=300)
+
+    plt.close("all")
+
+
+def test_GaussBeamTunable(packed_cube, coords, tmp_path):
     # show only the first channel
     chan = 0
-    layer = images.GaussBaseBeam(coords)
+    layer = images.GaussBaseBeamTunable(coords)
 
     for FWHM_base in np.linspace(-4, 0.5, num=10):
         fig, ax = plt.subplots(ncols=2)

--- a/test/input_output_test.py
+++ b/test/input_output_test.py
@@ -1,4 +1,3 @@
-import numpy as np
 
 from astropy.utils.data import download_file
 

--- a/test/input_output_test.py
+++ b/test/input_output_test.py
@@ -1,7 +1,7 @@
 
 from astropy.utils.data import download_file
-
 from mpol.input_output import ProcessFitsImage
+
 
 def test_ProcessFitsImage():
     # get a .fits file produced with casa
@@ -11,6 +11,6 @@ def test_ProcessFitsImage():
         show_progress=True,
         pkgname="mpol",
     )
-    
+
     fits_image = ProcessFitsImage(fname)
     clean_im, clean_im_ext, clean_beam = fits_image.get_image(beam=True)

--- a/test/losses_test.py
+++ b/test/losses_test.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import torch
-
 from mpol import coordinates, fourier, losses
 
 

--- a/test/onedim_test.py
+++ b/test/onedim_test.py
@@ -1,12 +1,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
-
 from mpol.onedim import radialI, radialV
 from mpol.plot import plot_image
 from mpol.utils import torch2npy
 
+
 def test_radialI(mock_1d_image_model, tmp_path):
-    # obtain a 1d radial brightness profile I(r) from an image    
+    # obtain a 1d radial brightness profile I(r) from an image
 
     rtrue, itrue, icube, _, _, geom = mock_1d_image_model
 
@@ -16,45 +16,45 @@ def test_radialI(mock_1d_image_model, tmp_path):
 
     fig, ax = plt.subplots(ncols=2, figsize=(10,5))
 
-    plot_image(np.squeeze(torch2npy(icube.sky_cube)), extent=icube.coords.img_ext, 
-               ax=ax[0], clab='Jy / sr')
+    plot_image(np.squeeze(torch2npy(icube.sky_cube)), extent=icube.coords.img_ext,
+               ax=ax[0], clab="Jy / sr")
 
-    ax[1].plot(rtrue, itrue, 'k', label='truth')
-    ax[1].plot(rtest, itest, 'r.-', label='recovery')
-    
+    ax[1].plot(rtrue, itrue, "k", label="truth")
+    ax[1].plot(rtest, itest, "r.-", label="recovery")
+
     ax[0].set_title(f"Geometry:\n{geom}", fontsize=7)
-    
-    ax[1].set_xlabel('r [arcsec]')
-    ax[1].set_ylabel('I [Jy / sr]')
+
+    ax[1].set_xlabel("r [arcsec]")
+    ax[1].set_ylabel("I [Jy / sr]")
     ax[1].legend()
 
     fig.savefig(tmp_path / "test_radialI.png", dpi=300)
     plt.close("all")
 
     expected = [
-        6.40747314e+10, 4.01920507e+10, 1.44803534e+10, 2.94238627e+09, 
-        1.28782935e+10, 2.68613199e+10, 2.26564596e+10, 1.81151845e+10, 
+        6.40747314e+10, 4.01920507e+10, 1.44803534e+10, 2.94238627e+09,
+        1.28782935e+10, 2.68613199e+10, 2.26564596e+10, 1.81151845e+10,
         1.52128965e+10, 1.05640352e+10, 1.33411204e+10, 1.61124502e+10,
-        1.41500539e+10, 1.20121195e+10, 1.11770326e+10, 1.19676913e+10, 
-        1.20941686e+10, 1.09498286e+10, 9.74236410e+09, 7.99589196e+09, 
+        1.41500539e+10, 1.20121195e+10, 1.11770326e+10, 1.19676913e+10,
+        1.20941686e+10, 1.09498286e+10, 9.74236410e+09, 7.99589196e+09,
         5.94787809e+09, 3.82074946e+09, 1.80823933e+09, 4.48414819e+08,
-        3.17808840e+08, 5.77317876e+08, 3.98851281e+08, 8.06459834e+08, 
-        2.88706161e+09, 6.09577814e+09, 6.98556762e+09, 4.47436415e+09, 
+        3.17808840e+08, 5.77317876e+08, 3.98851281e+08, 8.06459834e+08,
+        2.88706161e+09, 6.09577814e+09, 6.98556762e+09, 4.47436415e+09,
         1.89511273e+09, 5.96604356e+08, 3.44571640e+08, 5.65906765e+08,
-        2.85854589e+08, 2.67589013e+08, 3.98357054e+08, 2.97052261e+08, 
-        3.82744591e+08, 3.52239791e+08, 2.74336969e+08, 2.28425747e+08, 
+        2.85854589e+08, 2.67589013e+08, 3.98357054e+08, 2.97052261e+08,
+        3.82744591e+08, 3.52239791e+08, 2.74336969e+08, 2.28425747e+08,
         1.82290043e+08, 3.16077299e+08, 1.18465538e+09, 3.32239287e+09,
-        5.26718846e+09, 5.16458748e+09, 3.58114198e+09, 2.13431954e+09, 
-        1.40936556e+09, 1.04032244e+09, 9.24050422e+08, 8.46829316e+08, 
+        5.26718846e+09, 5.16458748e+09, 3.58114198e+09, 2.13431954e+09,
+        1.40936556e+09, 1.04032244e+09, 9.24050422e+08, 8.46829316e+08,
         6.80909295e+08, 6.83812465e+08, 6.91856237e+08, 5.29227136e+08,
-        3.97557293e+08, 3.54893419e+08, 2.60997039e+08, 2.09306498e+08, 
-        1.93930693e+08, 6.97032407e+07, 6.66090083e+07, 1.40079594e+08, 
+        3.97557293e+08, 3.54893419e+08, 2.60997039e+08, 2.09306498e+08,
+        1.93930693e+08, 6.97032407e+07, 6.66090083e+07, 1.40079594e+08,
         7.21775931e+07, 3.23902663e+07, 3.35932300e+07, 7.63318789e+06,
-        1.29740981e+07, 1.44300351e+07, 8.06249624e+06, 5.85567843e+06, 
-        1.42637174e+06, 3.21445075e+06, 1.83763663e+06, 1.16926652e+07, 
+        1.29740981e+07, 1.44300351e+07, 8.06249624e+06, 5.85567843e+06,
+        1.42637174e+06, 3.21445075e+06, 1.83763663e+06, 1.16926652e+07,
         2.46918188e+07, 1.60206523e+07, 3.26596592e+06, 1.27837319e+05,
-        2.27104612e+04, 4.77267063e+03, 2.90467640e+03, 2.88482230e+03, 
-        1.43402521e+03, 1.54791996e+03, 7.23397046e+02, 1.02561351e+03, 
+        2.27104612e+04, 4.77267063e+03, 2.90467640e+03, 2.88482230e+03,
+        1.43402521e+03, 1.54791996e+03, 7.23397046e+02, 1.02561351e+03,
         5.24845888e+02, 1.47320552e+03, 7.40419174e+02, 4.59029378e-03,
         0.00000000e+00, 0.00000000e+00, 0.00000000e+00
         ]
@@ -74,17 +74,17 @@ def test_radialV(mock_1d_vis_model, tmp_path):
 
     fig, ax = plt.subplots(ncols=1, nrows=2, figsize=(10,10))
 
-    ax[0].plot(q_dep / 1e6, Vtrue_dep.real, 'k.', label='truth deprojected')
-    ax[0].plot(qtest / 1e3, Vtest.real, 'r.-', label='recovery')
+    ax[0].plot(q_dep / 1e6, Vtrue_dep.real, "k.", label="truth deprojected")
+    ax[0].plot(qtest / 1e3, Vtest.real, "r.-", label="recovery")
 
-    ax[1].plot(q_dep / 1e6, Vtrue_dep.imag, 'k.')
-    ax[1].plot(qtest / 1e3, Vtest.imag, 'r.')  
+    ax[1].plot(q_dep / 1e6, Vtrue_dep.imag, "k.")
+    ax[1].plot(qtest / 1e3, Vtest.imag, "r.")
 
     ax[0].set_xlim(-0.5, 6)
     ax[1].set_xlim(-0.5, 6)
-    ax[1].set_xlabel(r'Baseline [M$\lambda$]')
-    ax[0].set_ylabel('Re(V) [Jy]')
-    ax[1].set_ylabel('Im(V) [Jy]')
+    ax[1].set_xlabel(r"Baseline [M$\lambda$]")
+    ax[0].set_ylabel("Re(V) [Jy]")
+    ax[1].set_ylabel("Im(V) [Jy]")
     ax[0].set_title(f"Geometry {geom}", fontsize=10)
     ax[0].legend()
 
@@ -120,4 +120,4 @@ def test_radialV(mock_1d_vis_model, tmp_path):
         ]
 
     np.testing.assert_allclose(Vtest.real, expected, rtol=1e-6,
-                               err_msg="test_radialV")    
+                               err_msg="test_radialV")

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -1,8 +1,5 @@
-import numpy as np
 
-from astropy.utils.data import download_file
 
-from mpol import precomposed
 # from mpol.plot import image_comparison_fig
 
 # def test_image_comparison_fig(coords, tmp_path):

--- a/test/plot_test.py
+++ b/test/plot_test.py
@@ -20,10 +20,10 @@
 #         pkgname="mpol",
 #     )
 
-#     image_comparison_fig(model, u, v, V, weights, robust=0.5, 
+#     image_comparison_fig(model, u, v, V, weights, robust=0.5,
 #                             clean_fits=fname,
-#                             share_cscale=False, 
+#                             share_cscale=False,
 #                             xzoom=[-2, 2], yzoom=[-2, 2],
 #                             title="test",
-#                             save_prefix=None,                            
+#                             save_prefix=None,
 #                             )

--- a/test/train_test_test.py
+++ b/test/train_test_test.py
@@ -2,13 +2,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.optim
-from torch.utils.tensorboard import SummaryWriter
-
 from mpol import losses, precomposed
+
 # from mpol.plot import train_diagnostics_fig
 # from mpol.training import TrainTest, train_to_dirty_image
 from mpol.utils import torch2npy
-
+from torch.utils.tensorboard import SummaryWriter
 
 # def test_traintestclass_training(coords, imager, dataset, generic_parameters):
 #     # using the TrainTest class, run a training loop without regularizers
@@ -16,7 +15,7 @@ from mpol.utils import torch2npy
 #     model = precomposed.GriddedNet(coords=coords, nchan=nchan)
 
 #     train_pars = generic_parameters["train_pars"]
-    
+
 #     # no regularizers
 #     train_pars["regularizers"] = {}
 
@@ -29,7 +28,7 @@ from mpol.utils import torch2npy
 
 
 # def test_traintestclass_training_scheduler(coords, imager, dataset, generic_parameters):
-#     # using the TrainTest class, run a training loop with regularizers, 
+#     # using the TrainTest class, run a training loop with regularizers,
 #     # using the learning rate scheduler
 #     nchan = dataset.nchan
 #     model = precomposed.GriddedNet(coords=coords, nchan=nchan)
@@ -54,11 +53,11 @@ from mpol.utils import torch2npy
 #     nchan = dataset.nchan
 #     model = precomposed.GriddedNet(coords=coords, nchan=nchan)
 
-#     train_pars = generic_parameters["train_pars"] 
+#     train_pars = generic_parameters["train_pars"]
 
 #     learn_rate = generic_parameters["crossval_pars"]["learn_rate"]
 
-#     train_pars['regularizers']['entropy']['guess'] = True 
+#     train_pars['regularizers']['entropy']['guess'] = True
 
 #     optimizer = torch.optim.Adam(model.parameters(), lr=learn_rate)
 
@@ -67,8 +66,8 @@ from mpol.utils import torch2npy
 
 
 # def test_traintestclass_train_diagnostics_fig(coords, imager, dataset, generic_parameters, tmp_path):
-#     # using the TrainTest class, run a training loop, 
-#     # and generate the train diagnostics figure 
+#     # using the TrainTest class, run a training loop,
+#     # and generate the train diagnostics figure
 #     nchan = dataset.nchan
 #     model = precomposed.GriddedNet(coords=coords, nchan=nchan)
 
@@ -87,8 +86,8 @@ from mpol.utils import torch2npy
 
 #     old_mod_im = torch2npy(model.icube.sky_cube[0])
 
-#     train_fig, train_axes = train_diagnostics_fig(model, 
-#                                                   losses=loss_history, 
+#     train_fig, train_axes = train_diagnostics_fig(model,
+#                                                   losses=loss_history,
 #                                                   learn_rates=learn_rates,
 #                                                   fluxes=np.zeros(len(loss_history)),
 #                                                   old_model_image=old_mod_im
@@ -111,7 +110,7 @@ from mpol.utils import torch2npy
 
 
 def test_standalone_init_train(coords, dataset):
-    # not using TrainTest class, 
+    # not using TrainTest class,
     # configure a class to train with and test that it initializes
 
     nchan = dataset.nchan
@@ -131,7 +130,7 @@ def test_standalone_init_train(coords, dataset):
 
 
 def test_standalone_train_loop(coords, dataset_cont, tmp_path):
-    # not using TrainTest class, 
+    # not using TrainTest class,
     # set everything up to run on a single channel
     # and run a few iterations
 
@@ -176,7 +175,7 @@ def test_standalone_train_loop(coords, dataset_cont, tmp_path):
 
 
 def test_tensorboard(coords, dataset_cont):
-    # not using TrainTest class, 
+    # not using TrainTest class,
     # set everything up to run on a single channel and then
     # test the writer function
 

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -3,8 +3,6 @@ import numpy as np
 import pytest
 
 from mpol import coordinates, utils
-from mpol.constants import *
-
 
 @pytest.fixture
 def imagekw():

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,8 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
 from mpol import coordinates, utils
+
 
 @pytest.fixture
 def imagekw():


### PR DESCRIPTION
This feature branch includes changes to introduce Stochastic Gradient Descent workflow

* Reorganize SimpleNet and the entire GriddedDataset workflow as an alternative option to SGD, with documentation about the use cases when one or the other might be preferred. closes #251 
* Documentation/"Getting Started" to explain how MPoL library usage follows the the normal ML paradigm with SGD closes #188
* SGD example shows how to create a `TensorDataset` and a `DataLoader` closes #162 
* Added a fixed FWHM Gaussian convolution routine to set base resolution.